### PR TITLE
.travis.yml: Don't bother spinning up a job for non-master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 ---
 language: generic
 
+branches:
+  only:
+  - master
+
 deploy:
   - provider: script
     script: ./publish-website.sh


### PR DESCRIPTION
CI doesn't do anything for branches other than `master`, but it still spins up a job for them and clones the repo... then immediately exits.  Optimize that out.