### PR TITLE
Bump Pro version 0.3.0 → 0.3.1

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -1,2 +1,2 @@
 version: 0.53.1
-aproVersion: 0.3.0
+aproVersion: 0.3.1


### PR DESCRIPTION
The only change is that it no longer requires root.