### PR TITLE
Add some cross links to the SNI page

### DIFF
--- a/user-guide/cert-manager.md
+++ b/user-guide/cert-manager.md
@@ -25,6 +25,8 @@ An `Issuer` or `ClusterIssuer` identifies which Certificate Authority cert-manag
 ### Certificate
 A [Certificate](https://cert-manager.readthedocs.io/en/latest/reference/certificates.html) is a namespaced resource that references an `Issuer` or `ClusterIssuer` for issuing certificates. `Certificate`s define the DNS name(s) a key and certificate should be issued for, as well as the secret to store those files (e.g. `ambassador-certs`). Configuration depends on which ACME [challenge](/user-guide/cert-manager#challenge) you are using.
 
+By duplicating issuers, certificates, and secrets one can support multiple domains with [SNI](/user-guide/sni).
+
 ### Challenge
 cert-manager supports two kinds of ACME challenges which verify domain ownership in different ways: HTTP-01 and DNS-01.
 

--- a/user-guide/sni.md
+++ b/user-guide/sni.md
@@ -2,7 +2,7 @@
 
 Ambassador lets you supply separate TLS certificates for different domains, instead of using a single TLS certificate for all domains. This allows Ambassador to serve multiple secure connections on the same IP address without requiring all websites to use the same certificate. Ambassador supports this use case through its support of Server Name Indication, an extension to the TLS protocol.
 
-Note: SNI is only available in the [0.50 early access release](/user-guide/early-access).
+Note: SNI is only available since the [0.50 early access release](/user-guide/early-access).
 
 ## Configuring SNI
 
@@ -157,4 +157,4 @@ spec:
   ports:
   - port: 80
     targetPort: 80
-```
+``````

--- a/user-guide/tls-termination.md
+++ b/user-guide/tls-termination.md
@@ -179,3 +179,8 @@ spec:
 ## Certificate Manager
 
 Jetstack's [cert-manager](https://github.com/jetstack/cert-manager) lets you easily provision and manage TLS certificates on Kubernetes. See documentation on using [cert-manager with Ambassador](/user-guide/cert-manager).
+
+## Supporting multiple domains
+
+With the setup from above it is not possible to supply separate certificates for different domains.
+This can be achieved with Ambassador's [SNI support](/user-guide/sni).


### PR DESCRIPTION
As I was just looking for TLS and not SNI I was initially pretty confused as I could not fogure out how to handle the case of multiple domains.

Maybe these additions can be the missing hint.