### PR TITLE
Fix typo in enable endpoints env

### DIFF
--- a/reference/core/load-balancer.md
+++ b/reference/core/load-balancer.md
@@ -1,6 +1,6 @@
 # Load Balancing in Ambassador
 
-Ambassador lets users control how it load balances between resulting endpoints for a given mapping. This feature ships in Early Access for Ambassador 0.52, and requires setting the environment variable `AMASSADOR_ENABLE_ENDPOINTS` to `true` to enable this feature.
+Ambassador lets users control how it load balances between resulting endpoints for a given mapping. This feature ships in Early Access for Ambassador 0.52, and requires setting the environment variable `AMBASSADOR_ENABLE_ENDPOINTS` to `true` to enable this feature.
 
 Load balancing configuration can be set for all Ambassador mappings in the [ambassador](/reference/core/ambassador) module, or set per [mapping](https://www.getambassador.io/reference/mappings#configuring-mappings). If nothing is set, simple round robin balancing is used via Kubernetes services.
 


### PR DESCRIPTION
Confirmed in https://github.com/datawire/ambassador/blob/bbb98dc1fc7bb36a7288020d50cb34b5f2bd2b12/ambassador/tests/abstract_tests.py#L114 that this should be the name of the project :)