### PR TITLE
Update docker-compose.md

### DIFF
--- a/user-guide/docker-compose.md
+++ b/user-guide/docker-compose.md
@@ -275,8 +275,12 @@ Make a new file called `config/auth.yaml` with an auth definition inside:
 apiVersion: ambassador/v1
 kind:  AuthService
 name:  authentication
-auth_service: "auth:3000"
+auth_service: "example-auth:3000"
 path_prefix: "/extauth"
+allowed_request_headers:
+- "x-qotm-session"
+allowed_authorization_headers:
+- "x-qotm-session"
 ```
 
 This configuration will use the `AuthService` object to ensure that all requests made to ambassador are first sent to the `auth` docker container on port `3000` before being routed to the service that is mapped to the desired route. See the Authentication documentation for more details.

--- a/user-guide/docker-compose.md
+++ b/user-guide/docker-compose.md
@@ -277,8 +277,6 @@ kind:  AuthService
 name:  authentication
 auth_service: "auth:3000"
 path_prefix: "/extauth"
-allowed_headers:
-- "x-qotm-session"
 ```
 
 This configuration will use the `AuthService` object to ensure that all requests made to ambassador are first sent to the `auth` docker container on port `3000` before being routed to the service that is mapped to the desired route. See the Authentication documentation for more details.


### PR DESCRIPTION
Was following this guide and found the auth config example here was not working for me until I removed the following from `config/auth.yaml`:
```
allowed_headers:
- "x-qotm-session"
```
Not certain if removing this field the best course to fix this problem. This was the error I was receiving until I removed the above code:
```
ERROR: auth.yaml.1: <RichStatus BAD error=not a valid AuthService: Additional properties are not allowed ('allowed_headers' was unexpected)
```