### PR TITLE
Update documentation to add apiextensions rule to RBAC configuration

### DIFF
--- a/reference/core/crds.md
+++ b/reference/core/crds.md
@@ -67,6 +67,9 @@ rules:
 - apiGroups: [ "getambassador.io" ]
   resources: [ "*" ]
   verbs: ["get", "list", "watch"]
+- apiGroups: [ "apiextensions.k8s.io" ]
+  resources: [ "customresourcedefinitions" ]
+  verbs: ["get", "list", "watch"]
 ```
 
 ## Creating the CRD types within Kubernetes


### PR DESCRIPTION
[This change in 0.70.1](https://github.com/datawire/ambassador/pull/1560/files) requires access to the CRDs via the k8s API which requires additional rules in the RBAC configuration. This PR updates the documentation to reflect these necessary changes.