### PR TITLE
Add extended documentation for prefix_regex

### DIFF
--- a/doc-links.yml
+++ b/doc-links.yml
@@ -127,6 +127,8 @@
               link: /reference/headers
             - title: Host Header
               link: /reference/host
+            - title: Prefix Regex
+              link: /reference/prefix_regex
             - title: Rate Limits
               link: /reference/rate-limits
             - title: Redirects

--- a/reference/mappings.md
+++ b/reference/mappings.md
@@ -36,7 +36,7 @@ Ambassador supports a number of attributes to configure and customize mappings.
 | [`load_balancer`](/reference/core/load-balancer) | configures load balancer on a mapping
 | [`method`](/reference/method)                  | defines the HTTP method for this mapping (e.g. GET, PUT, etc. -- must be all uppercase) |
 | `method_regex`            | if true, tells the system to interpret the `method` as a [regular expression](http://en.cppreference.com/w/cpp/regex/ecmascript) |
-| `prefix_regex`            | if true, tells the system to interpret the `prefix` as a [regular expression](http://en.cppreference.com/w/cpp/regex/ecmascript) and require the entire path must match the regex, not just the prefix. |
+| `prefix_regex`            | if true, tells the system to interpret the `prefix` as a [regular expression](http://en.cppreference.com/w/cpp/regex/ecmascript) and requires that the entire path must match the regex, not just the prefix. |
 | [`rate_limits`](/reference/rate-limits) | specifies a list rate limit rules on a mapping |
 | [`remove_request_headers`](/reference/remove_request_headers) | specifies a list of HTTP headers that are dropped from the request before sending to upstream |
 | [`remove_response_headers`](/reference/remove_response_headers) | specifies a list of HTTP headers that are dropped from the response before sending to client |

--- a/reference/mappings.md
+++ b/reference/mappings.md
@@ -36,7 +36,7 @@ Ambassador supports a number of attributes to configure and customize mappings.
 | [`load_balancer`](/reference/core/load-balancer) | configures load balancer on a mapping
 | [`method`](/reference/method)                  | defines the HTTP method for this mapping (e.g. GET, PUT, etc. -- must be all uppercase) |
 | `method_regex`            | if true, tells the system to interpret the `method` as a [regular expression](http://en.cppreference.com/w/cpp/regex/ecmascript) |
-| `prefix_regex`            | if true, tells the system to interpret the `prefix` as a [regular expression](http://en.cppreference.com/w/cpp/regex/ecmascript) |
+| `prefix_regex`            | if true, tells the system to interpret the `prefix` as a [regular expression](http://en.cppreference.com/w/cpp/regex/ecmascript) and require the entire path must match the regex, not just the prefix. |
 | [`rate_limits`](/reference/rate-limits) | specifies a list rate limit rules on a mapping |
 | [`remove_request_headers`](/reference/remove_request_headers) | specifies a list of HTTP headers that are dropped from the request before sending to upstream |
 | [`remove_response_headers`](/reference/remove_response_headers) | specifies a list of HTTP headers that are dropped from the response before sending to client |

--- a/reference/prefix_regex.md
+++ b/reference/prefix_regex.md
@@ -1,0 +1,23 @@
+# Prefix regex
+
+## Using `prefix` and `prefix_regex`
+
+When the `prefix_regex` attribute is set to `true`, ambassador configures a regex route instead of a prefix route in envoy. **This means the entire path must match the regex specified, not only the prefix.** 
+
+## Example with version in url
+
+If the version is a path parameter and the resources are served by different services, then
+
+```yaml
+---
+apiVersion: ambassador/v1
+kind:  Mapping
+name:  qotm_mapping
+prefix: "/(v1|v2)/qotm/.*"
+prefix_regex: true
+service: qotm
+```
+
+will map requests to both `/v1` and `/v2` to the `qotm` service.
+
+Note that enclosing regular expressions in quotes can be important to prevent backslashes from being doubled.

--- a/reference/prefix_regex.md
+++ b/reference/prefix_regex.md
@@ -2,7 +2,7 @@
 
 ## Using `prefix` and `prefix_regex`
 
-When the `prefix_regex` attribute is set to `true`, ambassador configures a regex route instead of a prefix route in envoy. **This means the entire path must match the regex specified, not only the prefix.** 
+When the `prefix_regex` attribute is set to `true`, ambassador configures a [regex route](https://www.envoyproxy.io/docs/envoy/v1.5.0/api-v1/route_config/route#route) instead of a prefix route in envoy. **This means the entire path must match the regex specified, not only the prefix.** 
 
 ## Example with version in url
 


### PR DESCRIPTION
Added extended documentation for `prefix_regex`. It's not obvious that the `prefix` needs to match the entire route.

Slack thread for more context: https://datawire-oss.slack.com/archives/CAULN7S76/p1559808604115800