### PR TITLE
Update for the pending Pro 0.5.0 release

### DIFF
--- a/doc-links.yml
+++ b/doc-links.yml
@@ -174,6 +174,12 @@
               link: /reference/idp-support/okta
             - title: User Account and Authentication (UAA)
               link: /reference/idp-support/uaa
+        - title: Pro
+          items:
+            - title: Environment
+              link: /reference/pro/environment
+            - title: Authentication
+              link: /reference/pro/authentication
         - title: Custom Resource Definitions
           link: /reference/core/crds
         - title: Filters

--- a/docs/dev-guide/service-preview.md
+++ b/docs/dev-guide/service-preview.md
@@ -13,6 +13,8 @@ Download the latest version of the client:
 
 Make sure the client is somewhere on your PATH. In addition, place your license key in `~/.ambassador.key`.
 
+Information about open source code used in `apictl` can be found by running `apictl --version`.
+
 ## Getting started
 
 In this quick start, we're going to preview a change we make to the backend service of the tour application, without impacting normal users of the application. Before getting started, make sure the [tour application is installed](https://www.getambassador.io/user-guide/getting-started#3-creating-your-first-service) on your cluster and you've installed the `apictl` command line tool, as explained above.

--- a/docs/guides/filter-dev-guide.md
+++ b/docs/guides/filter-dev-guide.md
@@ -52,6 +52,8 @@ To install the runner, download the latest version:
 
 Note that the plugin runner must match the version of Ambassador Pro that you are running. Place the binary somewhere in your `$PATH`.
 
+Information about open source code used in `apro-plugin-runner` can be found by running `apro-plugin-runner --version`.
+
 Now, you can quickly test and develop your filter.
 
 1. In your filter directory, type: `apro-plugin-runner :8080 ./param-plugin.so`.

--- a/pro-pages.yml
+++ b/pro-pages.yml
@@ -15,6 +15,8 @@
 - /reference/idp-support/auth0
 - /reference/idp-support/okta
 - /reference/idp-support/uaa
+- /reference/pro/authentication
+- /reference/pro/environment
 - /docs/guides/filter-dev-guide
 - /docs/dev-guide/service-preview
 - /about/support

--- a/reference/filter-reference.md
+++ b/reference/filter-reference.md
@@ -124,25 +124,27 @@ spec:
     MaxStale:         "duration-string" # optional; default is "0"
 ```
 
- - `authorizationURL` identifies where to look for the
+ - `authorizationURL`: Identifies where to look for the
    `/.well-known/openid-configuration` descriptor to figure out how to
    talk to the OAuth2 provider.
- - `clientURL` identifies a hostname that can appropriately set cookies
-   for the application.  Only the scheme (`https://`) and authority
-   (`example.com:1234`) parts are used; the path part of the URL is
-   ignored.
- - stateTTL: How long Ambassador will wait for the user to submit credentials to the IDP and receive a response to that effect from the IDP
- - `insecureTLS` disables TLS verification when speeking to an
-   `https://` IDP.  This is discouraged in favor of either using plain
-   `http://` or [installing a self-signed
+ - `clientURL`: Identifies a hostname that can appropriately set
+   cookies for the application.  Only the scheme (`https://`) and
+   authority (`example.com:1234`) parts are used; the path part of the
+   URL is ignored.
+ - `stateTTL`: How long Ambassador will wait for the user to submit
+   credentials to the identity provider and receive a response to that
+   effect from the identity provider
+ - `insecureTLS` disables TLS verification when speaking to an
+   `https://` identity provider.  This is discouraged in favor of
+   either using plain `http://` or [installing a self-signed
    certificate](#installing-self-signed-certificates).
- - audience: The OIDC audience.
- - clientID: The client ID you get from your IDP.
- - secret: The client secret you get from your IDP.
- - `maxStale`: How long to keep stale cache OIDC replies for.  This
+ - `audience`: The OIDC audience.
+ - `clientID`: The Client ID you get from your identity provider.
+ - `secret`: The client secret you get from your identity provider.
+ - `maxStale`: How long to keep stale cached OIDC replies for.  This
    sets the `max-stale` Cache-Control directive on requests, and also
    ignores the `no-store` and `no-cache` Cache-Control directives on
-   responses.  This is useful for working with IDPs with
+   responses.  This is useful for working with identity providers with
    mis-configured Cache-Control.
 
 `"duration-string"` strings are parsed as a sequence of decimal

--- a/reference/filter-reference.md
+++ b/reference/filter-reference.md
@@ -193,8 +193,21 @@ spec:
         - "scope2"
 ```
 
-You may specify a list of OAuth2 scopes to apply to the authorization
-request.
+You may specify a list of OAuth scope values to include in the scope
+of the authorization request.  If one of the scope values for a path
+is not granted, then access to that resource is forbidden; if the
+`scopes` argument lists `foo`, but the authorization response from the
+provider does not include `foo` in the scope, then it will be taken to
+mean that the authorization server forbade access to this path, as the
+authenticated user does not have the `foo` resource scope.
+
+The `openid` scope value is always included in the requested scope,
+even if it is not listed in the `FilterPolicy` argument.
+
+As a special case, if the `offline_access` scope value is requested,
+but not included in the response then access is not forbidden.  With
+many identity providers, requesting the `offline_access` scope is
+necessary in order to receive a Refresh Token.
 
 ### Filter Type: `Plugin`
 
@@ -338,7 +351,7 @@ spec:
 ## Installing self-signed certificates
 
 The JWT and OAuth2 filters speak to other servers over HTTP or HTTPS.
-If those servers are condifured to speak HTTPS using a self-signed
+If those servers are configured to speak HTTPS using a self-signed
 certificate, attempting to talk to them will result in a error
 mentioning `ERR x509: certificate signed by unknown authority`.  You
 can fix this by installing that self-signed certificate in to the Pro

--- a/reference/filter-reference.md
+++ b/reference/filter-reference.md
@@ -114,14 +114,14 @@ metadata:
   name: "example-filter"
 spec:
   OAuth2:
-    authorizationURL: "url-string"      # required
-    clientURL:        "url-string"      # required
-    stateTTL:         "duration-string" # optional; default is "5m"
-    insecureTLS:      bool              # optional; default is false
-    audience:         "string"
-    clientID:         "string"
-    secret:           "string"
-    MaxStale:         "duration-string" # optional; default is "0"
+    authorizationURL:      "url-string"      # required
+    clientURL:             "url-string"      # required
+    stateTTL:              "duration-string" # optional; default is "5m"
+    insecureTLS:           bool              # optional; default is false
+    clientID:              "string"
+    secret:                "string"
+    maxStale:              "duration-string" # optional; default is "0"
+    accessTokenValidation: "enum-string"     # optional; default is "auto"
 ```
 
  - `authorizationURL`: Identifies where to look for the
@@ -138,7 +138,7 @@ spec:
    `https://` identity provider.  This is discouraged in favor of
    either using plain `http://` or [installing a self-signed
    certificate](#installing-self-signed-certificates).
- - `audience`: The OIDC audience.
+   <!-- - `audience`: The OIDC audience. -->
  - `clientID`: The Client ID you get from your identity provider.
  - `secret`: The client secret you get from your identity provider.
  - `maxStale`: How long to keep stale cached OIDC replies for.  This
@@ -146,6 +146,26 @@ spec:
    ignores the `no-store` and `no-cache` Cache-Control directives on
    responses.  This is useful for working with identity providers with
    mis-configured Cache-Control.
+ - `accessTokenValidation`: How to verify the liveness and scope of
+   Access Tokens issued by the identity provider.  Valid values are
+   either `"auto"`, `"jwt"`, or `"userinfo"`.  Empty or unset is
+   equivalent to `"auto"`.
+   * `"jwt"`: Validates the Access Token as a JWT.  It accepts the
+     RS256, RS384, or RS512 signature algorithms, and validates the
+     signature against the JWKS from OIDC Discovery.  It then
+     validates the `exp`, `iat`, `nbf`, `iss` (with the Issuer from
+     OIDC Discovery), and `scope` claims; if present, none of the
+     scopes are required to be present.  This relies on the identity
+     provider using non-encrypted signed JWTs as Access Tokens, and
+     configuring the signing appropriately.
+   * `"userinfo"`: Validates the access token by polling the OIDC
+     UserInfo Endpoint.  This means that Ambassador Pro must initiate
+     an HTTP request to the identity provider for each authorized request to a
+     protected resource.  This performs poorly, but functions properly
+     with a wider range of identity providers.
+   * `"auto"` attempts has it do `"jwt"` validation if the Access
+     Token parses as a JWT and the signature is valid, and otherwise
+     falls back to `"userinfo"` validation.
 
 `"duration-string"` strings are parsed as a sequence of decimal
 numbers, each with optional fraction and a unit suffix, such as

--- a/reference/pro/authentication.md
+++ b/reference/pro/authentication.md
@@ -1,0 +1,22 @@
+# Ambassador Pro Authentication
+
+## Overview
+
+Ambassador Pro supports the Authorization Code Flow authentication flow. On an incoming request, Ambassador will check for a cookie called `ambassador_session`. If the cookie is not present, Ambassador Pro will redirect the request to an IDP for user authentication. Upon a successful authentication by the IDP, Ambassador Pro will set the cookie. Subsequent requests will be validated directly by Ambassador Pro without requiring an additional query to the IDP.
+
+## OAuth protocol
+
+The Ambassador Pro OAuth2 filter does two things:
+
+* It is an OAuth Client, which feteches resources from the Resource Server on the user's behalf.
+* It is half of a Resource Server, validating the Access Token before allowing the request through to the upstream service, which implements the other half of the Resource Server.
+
+This is different from most OAuth implementations where the Authorization Server and the Resource Server are in the same security domain. With Ambassador Pro, the Client and the Resource Server are in the same security domain, and there is an independent Authorization Server.
+
+## XSRF protection
+
+The `ambassador_session` is an opaque string that should be used as an XSRF token. This token is used in `/callback` to prevent XSRF attacks.
+
+## Redis
+
+Ambassador Pro relies on Redis to store short-lived authentication credentials and rate limiting information. If the Redis data store is lost, users will need to log back in and all existing rate limits would be reset.

--- a/reference/pro/authentication.md
+++ b/reference/pro/authentication.md
@@ -2,20 +2,25 @@
 
 ## Overview
 
-Ambassador Pro supports the Authorization Code Flow authentication flow. On an incoming request, Ambassador will check for a cookie called `ambassador_session`. If the cookie is not present, Ambassador Pro will redirect the request to an IDP for user authentication. Upon a successful authentication by the IDP, Ambassador Pro will set the cookie. Subsequent requests will be validated directly by Ambassador Pro without requiring an additional query to the IDP.
+Ambassador Pro supports the Authorization Code Flow authentication flow.  On an incoming request, Ambassador Pro will look up session information based on a cookie called `ambassador_session.NAME.NAMESPACE`, where `NAME` and `NAMESPACE` describe the [`Filter` resource](../filter-reference#filter-type-oauth2) being used.  If the cookie is not present, refers to an expired session, or refers to a not-yet-authorized session, then Ambassador Pro will set the cookie and redirect the request to an IDP for user authentication.  Upon a successful authentication by the IDP, Ambassador Pro will mark the session as authorized, and redirect to the originally requested resource.  Depending on the [`accessTokenValidation` Filter setting](../filter-reference#oauth2-global-arguments) subsequent requests may be validated directly by Ambassador Pro without requiring an additional query to the IDP, or may be validated by making requests to the IDP.
 
-## OAuth protocol
+## OAuth 2.0 protocol
 
 The Ambassador Pro OAuth2 filter does two things:
 
-* It is an OAuth Client, which feteches resources from the Resource Server on the user's behalf.
+* It is an OAuth Client, which fetches resources from the Resource Server on the user's behalf.
 * It is half of a Resource Server, validating the Access Token before allowing the request through to the upstream service, which implements the other half of the Resource Server.
 
 This is different from most OAuth implementations where the Authorization Server and the Resource Server are in the same security domain. With Ambassador Pro, the Client and the Resource Server are in the same security domain, and there is an independent Authorization Server.
 
 ## XSRF protection
 
-The `ambassador_session` is an opaque string that should be used as an XSRF token. This token is used in `/callback` to prevent XSRF attacks.
+The `ambassador_session.NAME.NAMESPACE` cookie is an opaque string that should be used as an XSRF token.  Applications wishing to leverage Ambassador Pro in their XSRF attack protection should take two extra steps:
+
+ 1. When generating an HTML form, the server should read the cookie, and include a `<input type="hidden" name="_xsrf" value="COOKIE_VALUE" />` element in the form.
+ 2. When handling submitted form data should verify that the form value and the cookie value match.  If they do not match, it should refuse to handle the request, and return an HTTP 4XX response.
+
+Applications using request submission formats other than HTML forms should perform analogous steps of ensuring that the value is duplicated in the cookie and in the request body.
 
 ## Redis
 

--- a/reference/pro/environment.md
+++ b/reference/pro/environment.md
@@ -56,6 +56,17 @@ If `REDIS_PERSECOND` is true, a third Redis connection pool is created
 (to a potentially different Redis instance) that is only used for
 per-second RateLimits.
 
+If the `APRO_KEYPAIR_SECRET_NAME`/`APRO_KEYPAIR_SECRET_NAMESPACE`
+Kubernetes secret does not already exist when Ambassador Pro starts,
+it will be automatically created; which obviously requires permission
+in the ClusterRole to create secrets.  If the secret already exists
+(either because an earlier instance of Ambassador Pro already created
+it, or because it was created manually), then the "create" permission
+for secrets can be be removed from the ClusterRole.  If manually
+providing the secret, it must have the "Opaque" type, with two data
+fields: `rsa.key` and `rsa.crt`, which contain PEM-encoded RSA private
+and public keys respectively.
+
 [^1]: This may change in a future release to reflect the Pods's
     namespace if deployed to a namespace other than `default`.
     https://github.com/datawire/ambassador/issues/1583

--- a/reference/pro/environment.md
+++ b/reference/pro/environment.md
@@ -1,0 +1,64 @@
+# Environment variables for the Ambassador Pro container
+
+| Variable                        | Default                                           | Value type                                                                    | Purpose                       |
+|---------------------------------|---------------------------------------------------|-------------------------------------------------------------------------------|-------------------------------|
+| `AMBASSADOR_ID`                 | `default`                                         | plain string                                                                  | Ambassador                    |
+| `AMBASSADOR_NAMESPACE`          | `default`[^1]                                     | Kubernetes namespace                                                          | Ambassador                    |
+| `AMBASSADOR_SINGLE_NAMESPACE`   | empty                                             | Boolean; non-empty=true, empty=false                                          | Ambasador                     |
+|---------------------------------|---------------------------------------------------|-------------------------------------------------------------------------------|-------------------------------|
+| `APRO_AUTH_PORT`                | `8500`                                            | TCP port number or name                                                       | Filtering AuthService (gRPC)  |
+| `GRPC_PORT`                     | `8501`                                            | TCP port number or name                                                       | RateLimitService (gRPC)       |
+| `DEBUG_PORT`                    | `8502`                                            | TCP port number or name                                                       | RateLimitService debug (HTTP) |
+| `PORT`                          | `8503`                                            | TCP port number or name                                                       | RateLimitService misc (HTTP)  |
+|---------------------------------|---------------------------------------------------|-------------------------------------------------------------------------------|-------------------------------|
+| `APP_LOG_LEVEL`                 | `info`                                            | log level                                                                     | Filter                        |
+| `LOG_LEVEL`                     | `WARN`                                            | log level                                                                     | RateLimit                     |
+|---------------------------------|---------------------------------------------------|-------------------------------------------------------------------------------|-------------------------------|
+| `APRO_KEYPAIR_SECRET_NAME`      | `ambassador-pro-keypair`                          | Kubernetes name                                                               | Filter                        |
+| `APRO_KEYPAIR_SECRET_NAMESPACE` | use the value of `AMBASSADOR_NAMESPACE`           | Kubernetes namespace                                                          | Filter                        |
+| `REDIS_POOL_SIZE`               | `10`                                              | integer                                                                       | Filter, RateLimit             |
+| `REDIS_SOCKET_TYPE`             | none, must be set manually                        | Go network such as `tcp` or `unix`; see [Go `net.Dial`][]                     | Filter, RateLimit             |
+| `REDIS_URL`                     | none, must be set manually                        | Go network address; for TCP this is a `host:port` pair; see [Go `net.Dial`][] | Filter, RateLimit             |
+| `REDIS_PERSECOND`               | `false`                                           | Boolean; [Go `strconv.ParseBool`][]                                           | RateLimit                     |
+| `REDIS_PERSECOND_SOCKET_TYPE`   | none, must be set manually (if `REDIS_PERSECOND`) | Go network such as `tcp` or `unix`; see [Go `net.Dial`][]                     | RateLimit                     |
+| `REDIS_PERSECOND_POOL_SIZE`     | none, must be set manually (if `REDIS_PERSECOND`) | Go network address; for TCP this is a `host:port` pair; see [Go `net.Dial`][] | RateLimit                     |
+| `EXPIRATION_JITTER_MAX_SECONDS` | `300`                                             | integer                                                                       | RateLimit                     |
+
+<!--
+
+  The following variables are non-overridable in `run.sh`; don't add
+  them to the above table.
+  
+   cmd/amb-sidecar/types/config.go:
+    - `RLS_RUNTIME_DIR`
+
+   vendor-ratelimit/src/settings/settings.go:
+    - `USE_STATSD`
+       * `STATSD_HOST`
+       * `STATSD_PORT`
+    - `RUNTIME_ROOT`
+    - `RUNTIME_SUBDIRECTORY`
+
+-->
+
+Port names are well-known port names that are recognized by
+`/etc/services`, they are *not* Kubernetes port names.
+
+Log levels are case-insensitive. From least verbose to most verbose,
+valid log levels are `error`, `warn`/`warning`, `info`, `debug`, and
+`trace`.
+
+The AuthService and the RateLimitService each maintain a separate
+Redis connection pool; so there will be up to 2×`REDIS_POOL_SIZE`
+connections to Redis.
+
+If `REDIS_PERSECOND` is true, a third Redis connection pool is created
+(to a potentially different Redis instance) that is only used for
+per-second RateLimits.
+
+[^1]: This may change in a future release to reflect the Pods's
+    namespace if deployed to a namespace other than `default`.
+    https://github.com/datawire/ambassador/issues/1583
+
+[Go `net.Dial`]: https://golang.org/pkg/net/#Dial
+[Go `strconv.ParseBool`]: https://golang.org/pkg/strconv/#ParseBool

--- a/user-guide/ambassador-pro-install.md
+++ b/user-guide/ambassador-pro-install.md
@@ -3,6 +3,8 @@
 
 Ambassador Pro is a commercial version of Ambassador that includes integrated Single Sign-On, powerful rate limiting, custom filters, and more. Ambassador Pro also uses a certified version of Ambassador OSS that undergoes additional testing and validation. In this tutorial, we'll walk through the process of installing Ambassador Pro in Kubernetes and show the JWT filter in action.
 
+Information about open source code used in Ambassador Pro can be found in `/*.opensource.tar.gz` files in each Docker image.
+
 ## 1. Clone the Ambassador Pro configuration repository
 Ambassador Pro consists of a series of modules that communicate with Ambassador. The core Pro module is typically deployed as a sidecar to Ambassador. This means it is an additional process that runs on the same pod as Ambassador. Ambassador communicates with the Pro sidecar locally. Pro thus scales in parallel with Ambassador. Ambassador Pro also relies on a Redis instance for its rate limit service and several Custom Resource Definitions (CRDs) for configuration.
 

--- a/user-guide/upgrade-to-pro.md
+++ b/user-guide/upgrade-to-pro.md
@@ -2,6 +2,8 @@
 
 If you are already using Ambassador open source, upgrading to using Ambassador Pro is straight-forward. In this demo we will walk-through integrating Ambassador Pro into your currently running Ambassador instance and show how quickly you can secure your APIs with JWT authentication.
 
+Information about open source code used in Ambassador Pro can be found in `/*.opensource.tar.gz` files in each Docker image.
+
 ## 1. Clone the Ambassador Pro configuration repository
 
 Ambassador Pro is a module that communicates with Ambassador, exposing the various Pro services to Ambassador. Ambassador Pro is typically deployed as a sidecar service to Ambassador, allowing for it to communicate with Ambassador locally. While this is the recommended deployment topology, for evaluation purposes it is simpler to deploy Ambassador Pro as a separate service in your Kubernetes cluster. 

--- a/versions.yml
+++ b/versions.yml
@@ -1,4 +1,4 @@
 version: 0.72.0
-aproVersion: 0.4.3
+aproVersion: 0.5.0
 qotmVersion: 1.7
 tourVersion: 0.2.1


### PR DESCRIPTION
I think this updates everything for the changes in 0.5.0, and fills in information that was missing and should probably be documented (Closes apro#132).

I didn't mess with the list of supported IDPs, since I see that @nbkrause already has branches for that (the test suite now tests with 6 different IDPs: Auth0, Azure AD, Google, Keycloak, Okta, and UAA).

I documented all of the environment variables that are handled in the APro code in `reference/pro/environment.md`.  I also included in that file docs on the keypair secret; I'm not sure that page is the best place for that info, but I couldn't figure out a better place.