### PR TITLE
apro: Describe PORT (=8503) as being for RLS health, instead of "misc"

### DIFF
--- a/reference/pro/environment.md
+++ b/reference/pro/environment.md
@@ -9,7 +9,7 @@
 | `APRO_AUTH_PORT`                | `8500`                                            | TCP port number or name                                                       | Filtering AuthService (gRPC)  |
 | `GRPC_PORT`                     | `8501`                                            | TCP port number or name                                                       | RateLimitService (gRPC)       |
 | `DEBUG_PORT`                    | `8502`                                            | TCP port number or name                                                       | RateLimitService debug (HTTP) |
-| `PORT`                          | `8503`                                            | TCP port number or name                                                       | RateLimitService misc (HTTP)  |
+| `PORT`                          | `8503`                                            | TCP port number or name                                                       | RateLimitService health (HTTP) |
 |---------------------------------||||
 | `APP_LOG_LEVEL`                 | `info`                                            | log level                                                                     | Filter                        |
 | `LOG_LEVEL`                     | `WARN`                                            | log level                                                                     | RateLimit                     |

--- a/user-guide/ambassador-pro-install.md
+++ b/user-guide/ambassador-pro-install.md
@@ -51,12 +51,12 @@ reason those assignments are problematic (perhaps you [set
 `service_port`](/reference/running/#running-as-non-root) to one of
 those), you can set adjust these by setting environment variables:
 
-| Purpose                       | Variable         | Default |
-| ---                           | ---              | ---     |
-| Filtering AuthService (gRPC)  | `APRO_AUTH_PORT` | 8500    |
-| RateLimitService (gRPC)       | `GRPC_PORT`      | 8501    |
-| RateLimitService debug (HTTP) | `DEBUG_PORT`     | 8502    |
-| RateLimitService misc (HTTP)  | `PORT`           | 8503    |
+| Purpose                        | Variable         | Default |
+| ---                            | ---              | ---     |
+| Filtering AuthService (gRPC)   | `APRO_AUTH_PORT` | 8500    |
+| RateLimitService (gRPC)        | `GRPC_PORT`      | 8501    |
+| RateLimitService debug (HTTP)  | `DEBUG_PORT`     | 8502    |
+| RateLimitService health (HTTP) | `PORT`           | 8503    |
 
 If you have deployed Ambassador with
 [`AMBASSADOR_NAMESPACE`, `AMBASSADOR_SINGLE_NAMESPACE`](/reference/running/#namespaces), or

--- a/user-guide/upgrade-to-pro.md
+++ b/user-guide/upgrade-to-pro.md
@@ -47,12 +47,12 @@ reason those assignments are problematic (perhaps you [set
 `service_port`](/reference/running/#running-as-non-root) to one of
 those), you can set adjust these by setting environment variables:
 
-| Purpose                       | Variable         | Default |
-| ---                           | ---              | ---     |
-| Filtering AuthService (gRPC)  | `APRO_AUTH_PORT` | 8500    |
-| RateLimitService (gRPC)       | `GRPC_PORT`      | 8501    |
-| RateLimitService debug (HTTP) | `DEBUG_PORT`     | 8502    |
-| RateLimitService misc (HTTP)  | `PORT`           | 8503    |
+| Purpose                        | Variable         | Default |
+| ---                            | ---              | ---     |
+| Filtering AuthService (gRPC)   | `APRO_AUTH_PORT` | 8500    |
+| RateLimitService (gRPC)        | `GRPC_PORT`      | 8501    |
+| RateLimitService debug (HTTP)  | `DEBUG_PORT`     | 8502    |
+| RateLimitService health (HTTP) | `PORT`           | 8503    |
 
 If you have deployed Ambassador with
 [`AMBASSADOR_NAMESPACE`, `AMBASSADOR_SINGLE_NAMESPACE`](/reference/running/#namespaces), or


### PR DESCRIPTION
"misc" was a cop-out, since at the time I couldn't figure out what the RLS
was actually using it for.