### PR TITLE
Add ambassador_id in the ambassador core docs

### DIFF
--- a/reference/core/ambassador.md
+++ b/reference/core/ambassador.md
@@ -10,6 +10,9 @@ If present, the `ambassador` module defines system-wide configuration. This modu
 apiVersion: ambassador/v1
 kind:  Module
 name:  ambassador
+# Put the id if you are using multiple ambassadors in the same cluster.
+# For more information: https://www.getambassador.io/reference/running/#ambassador_id.
+# ambassador_id: "<ambassador_id>"
 config:
 # admin_port is the port where Ambassador's Envoy will listen for
 # low-level admin requests. You should almost never need to change


### PR DESCRIPTION
This optional field was missing, although we have a nice example in the [Running Ambassador page](https://www.getambassador.io/reference/running/#ambassador_id).