### PR TITLE
filter-reference: Fix syntax mistakes in the example JWT YAML

### DIFF
--- a/reference/filter-reference.md
+++ b/reference/filter-reference.md
@@ -175,39 +175,39 @@ spec:
     requireAudience: false
     injectRequestHeaders:
       - name: "X-Fixed-String"
-        value: "Fixed String",
+        value: "Fixed String"
         # result will be "Fixed String"
       - name: "X-Token-String"
-        value: "{{.token.Raw}}",
+        value: "{{.token.Raw}}"
         # result will be "eyJhbGciOiJub25lIiwidHlwIjoiSldUIiwiZXh0cmEiOiJzbyBtdWNoIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ."
       - name: "X-Token-H-Alg"
-        value: "{{.token.Header.alg}}",
+        value: "{{.token.Header.alg}}"
         # result will be "none"
       - name: "X-Token-H-Typ"
-        value: "{{.token.Header.typ}}",
+        value: "{{.token.Header.typ}}"
         # result will be "JWT"
       - name: "X-Token-H-Extra"
-        value: "{{.token.Header.extra}}",
+        value: "{{.token.Header.extra}}"
         # result will be "so much"
       - name: "X-Token-C-Sub"
-        value: "{{.token.Claims.sub}}",
+        value: "{{.token.Claims.sub}}"
         # result will be "1234567890"
       - name: "X-Token-C-Name"
-        value: "{{.token.Claims.name}}",
+        value: "{{.token.Claims.name}}"
         # result will be "John Doe"
       - name: "X-Token-C-Iat"
-        value: "{{.token.Claims.iat}}",
+        value: "{{.token.Claims.iat}}"
         # result will be "1.516239022e+09" (don't expect JSON numbers
         # to always be formatted the same as input; if you care about
         # that, specify the formatting; see the next example)
       - name: "X-Token-C-Iat-Decimal"
-        value: "{{printf \"%.0f\" .token.Claims.iat}}",
+        value: "{{printf \"%.0f\" .token.Claims.iat}}"
         # result will be "1516239022"
       - name: "X-Token-S"
-        value: "{{.token.Signature}}",
+        value: "{{.token.Signature}}"
         # result will be "" (since "alg: none" was used in this example JWT)
       - name: "X-Authorization"
-        value: : "Authenticated {{.token.Header.typ}}; sub={{.token.Claims.sub}}; name={{printf \"%q\" .token.Claims.name}}"
+        value: "Authenticated {{.token.Header.typ}}; sub={{.token.Claims.sub}}; name={{printf \"%q\" .token.Claims.name}}"
         # result will be: "Authenticated JWT; sub=1234567890; name="John Doe""
 ```
 


### PR DESCRIPTION
I had sloppily converted a Go struct to that example YAML.