### PR TITLE
Fix to AWS ELB L7 documentation

### DIFF
--- a/reference/ambassador-with-aws.md
+++ b/reference/ambassador-with-aws.md
@@ -250,14 +250,13 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
     getambassador.io/config: |
       ---
       apiVersion: ambassador/v1
       kind:  Module
       name:  ambassador
       config:
-        use_proxy_proto: true
+        use_proxy_proto: false
         use_remote_address: false
         x_forwarded_proto_redirect: true
 spec:


### PR DESCRIPTION
This PR is to fix an error in the `ambassador-with-aws` chapter. The example in the paragraph about doing http redirect with an L7 elb is wrong:
- the `service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"` annotation has no sense because according with [AWS docs](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/using-elb-listenerconfig-quickref.html), in L7 elb it's not possible to use proxy protocol
- the `use_proxy_proto` option of the Ambassador module is set to `true` but in this way it doesn't work. It caused me hours of troubleshooting then I landed [here](https://www.getambassador.io/reference/core/ambassador/#use_proxy_proto) and understood that it's not possible to use HTTP with proxy proto. 