### PR TITLE
Fix typo in the cert-manager HTTP-01 challenge guide

### DIFF
--- a/user-guide/cert-manager.md
+++ b/user-guide/cert-manager.md
@@ -104,7 +104,7 @@ The HTTP-01 challenge verifies ownership of the domain by sending a request for 
     spec:
       prefix: /.well-known/acme-challenge
       rewrite: ""
-      service: acme-challeneg-service
+      service: acme-challenge-service
 
     ---
     apiVersion: v1


### PR DESCRIPTION
In step 4, the Mapping's spec had its service set to "service: acme-challeneg-service" with "challenge" misspelled as "challeneg"