### PR TITLE
Fix typo for deploying Grafana behind Ambassador

### DIFF
--- a/user-guide/monitoring.md
+++ b/user-guide/monitoring.md
@@ -180,7 +180,7 @@ spec:
             cpu: 100m
             memory: 100Mi
         env:
-          - name: GR_SERVER_ROOT_URL
+          - name: GF_SERVER_ROOT_URL
             value: {{AMBASSADOR_IP}}/grafana
           - name: GF_AUTH_BASIC_ENABLED
             value: "true"


### PR DESCRIPTION
To deploy Grafana behind Ambassador, the environment variable to be set to the IP of the Ambassador service is GF_SERVER_ROOT_URL, not GR_SERVER_ROOT_URL.

GR_SERVER_ROOT_URL -> GF_SERVER_ROOT_URL