### PR TITLE
Fix example in origination.md

### DIFF
--- a/reference/tls/origination.md
+++ b/reference/tls/origination.md
@@ -43,6 +43,7 @@ metadata:
 spec:
   prefix: /
   service: https://example-service
+  tls: tls
 ```
 
 The `example-service` service must now support tls v1.3 for Ambassador to connect.


### PR DESCRIPTION
Add missing but mentioned `tls` attribute to Advanced Configuration Using a `TLSContext`
mapping example