### PR TITLE
Update documentation for Cert-Manager v0.11.1

### DIFF
--- a/user-guide/cert-manager.md
+++ b/user-guide/cert-manager.md
@@ -1,23 +1,22 @@
-# Cert-Manager and Ambassador 
-Creating and managing certificates in Kubernetes is made simple with Jetstack's [cert-manager](https://github.com/jetstack/cert-manager). cert-manager will automatically create and renew tls certificates and store them in Kubernetes secrets for easy use in a cluster. 
+# Cert-Manager and Ambassador
+Creating and managing certificates in Kubernetes is made simple with Jetstack's [cert-manager](https://github.com/jetstack/cert-manager). cert-manager will automatically create and renew tls certificates and store them in Kubernetes secrets for easy use in a cluster.
 
 Starting in Ambassador 0.50.0, Ambassador will automatically watch for secret changes and reload certificates upon renewal.
 
 ## Install Cert-Manager
 There are many different ways to [install cert-manager](https://docs.cert-manager.io/en/latest/getting-started/install.html). For simplicity, we will use Helm.
 
-1. Create the CustomResourceDefinitions
+1. Install cert-manager
+
 ```
-kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/00-crds.yaml
+kubectl create ns cert-manager
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.11.1/cert-manager-no-webhook.yaml
 ```
-2. Install cert-manager
-```
-helm install -n cert-manager --set webhook.enabled=false stable/cert-manager
-```
+
 **Note:** The resource validation webhook is not required and requires addition configuration.
 
 ## Issuing Certificates
-cert-manager issues certificates from a CA such as [Let's Encrypt](https://letsencrypt.org/). It does this using the ACME protocol which supports various challenge mechanisms for verifying ownership of the domain. 
+cert-manager issues certificates from a CA such as [Let's Encrypt](https://letsencrypt.org/). It does this using the ACME protocol which supports various challenge mechanisms for verifying ownership of the domain.
 
 ### Issuer
 An `Issuer` or `ClusterIssuer` identifies which Certificate Authority cert-manager will use to issue a certificate. `Issuer` is a namespaced resource allowing for you to use different CAs in each namespace, a `ClusterIssuer` is used to issue certificates in any namespace. Configuration depends on which ACME [challenge](/user-guide/cert-manager#challenge) you are using.
@@ -30,28 +29,34 @@ By duplicating issuers, certificates, and secrets one can support multiple domai
 ### Challenge
 cert-manager supports two kinds of ACME challenges which verify domain ownership in different ways: HTTP-01 and DNS-01.
 
-#### HTTP-01 Challenge 
+#### HTTP-01 Challenge
 The HTTP-01 challenge verifies ownership of the domain by sending a request for a specific file on that domain. cert-manager accomplishes this by sending a request to a temporary pod with the prefix `/.well-known/acme-challenge`. To perform this challenge:
 
 1. Create a `ClusterIssuer`:
     ```yaml
     ---
-    apiVersion: certmanager.k8s.io/v1alpha1
+    apiVersion: cert-manager.io/v1alpha2
     kind: ClusterIssuer
     metadata:
       name: letsencrypt-prod
     spec:
       acme:
-        email: exampe@example.com
+        email: example@example.com
         server: https://acme-v02.api.letsencrypt.org/directory
         privateKeySecretRef:
           name: letsencrypt-prod
-        http01: {}
+        http01:
+          serviceType: ClusterIP
+        solvers:
+        - http01:
+            ingress:
+              class: nginx
+          selector: {}
     ```
 2. Configure a `Certificate` to use this `ClusterIssuer`:
     ```yaml
     ---
-    apiVersion: certmanager.k8s.io/v1alpha1
+    apiVersion: cert-manager.io/v1alpha2
     kind: Certificate
     metadata:
       name: ambassador-certs
@@ -73,7 +78,7 @@ The HTTP-01 challenge verifies ownership of the domain by sending a request for 
         - http01:
             ingressClass: nginx
           domains:
-         - example.com
+          - example.com
     ```
 3. Apply both the `ClusterIssuer` and `Certificate`
 
@@ -104,7 +109,7 @@ The HTTP-01 challenge verifies ownership of the domain by sending a request for 
     spec:
       prefix: /.well-known/acme-challenge
       rewrite: ""
-      service: acme-challeneg-service
+      service: acme-challenge-service
 
     ---
     apiVersion: v1
@@ -116,9 +121,9 @@ The HTTP-01 challenge verifies ownership of the domain by sending a request for 
       - port: 80
         targetPort: 8089
       selector:
-        certmanager.k8s.io/acme-http01-solver: "true"
+        acme.cert-manager.io/http01-solver: "true"
     ```
-    Apply the YAML and wait a couple of minutes. cert-manager will retry the challenge and issue the certificate. 
+    Apply the YAML and wait a couple of minutes. cert-manager will retry the challenge and issue the certificate.
 
 5. Verify the secret is created:
 
@@ -131,17 +136,17 @@ The HTTP-01 challenge verifies ownership of the domain by sending a request for 
     ```
 
 ### DNS-01 Challenge
-The DNS-01 challenge verifies domain ownership by proving you have control over its DNS records. Issuer configuration will depend on your [DNS provider](https://cert-manager.readthedocs.io/en/latest/tasks/acme/configuring-dns01/index.html#supported-dns01-providers). This example uses [AWS Route53](https://cert-manager.readthedocs.io/en/latest/tasks/acme/configuring-dns01/route53.html). 
+The DNS-01 challenge verifies domain ownership by proving you have control over its DNS records. Issuer configuration will depend on your [DNS provider](https://cert-manager.readthedocs.io/en/latest/tasks/acme/configuring-dns01/index.html#supported-dns01-providers). This example uses [AWS Route53](https://cert-manager.readthedocs.io/en/latest/tasks/acme/configuring-dns01/route53.html).
 
 1. Create the IAM policy specified in the cert-manager [AWS Route53](https://cert-manager.readthedocs.io/en/latest/tasks/acme/configuring-dns01/route53.html) documentation.
 
-2. Note the `accessKeyID` and create a secret named `prod-route53-credentials-secret` holding the `secret-access-key`. 
+2. Note the `accessKeyID` and create a secret named `prod-route53-credentials-secret` holding the `secret-access-key`.
 
 3. Create and apply a `ClusterIssuer`:
 
     ```yaml
     ---
-    apiVersion: certmanager.k8s.io/v1alpha1
+    apiVersion: cert-manager.io/v1alpha2
     kind: ClusterIssuer
     metadata:
       name: letsencrypt-prod
@@ -166,7 +171,7 @@ The DNS-01 challenge verifies domain ownership by proving you have control over 
 
     ```yaml
     ---
-    apiVersion: certmanager.k8s.io/v1alpha1
+    apiVersion: cert-manager.io/v1alpha2
     kind: Certificate
     metadata:
       name: ambassador-certs


### PR DESCRIPTION
Cert-Manager is now at version v0.11.1

Because the Cert-Manager CRD have now different `apiVersion`  the documentation was not working anymore.

I also dropped the Helm installation of Cert Manager, because with the migration from Helm V2 to Helm V3 that part is also confusing, for the purpose of this tutorial it is much easier to install Cert Manager from his official yaml manifest.