### PR TITLE
filter-reference.md: Fix typo: "defaulti"→"default"

### DIFF
--- a/reference/filter-reference.md
+++ b/reference/filter-reference.md
@@ -127,7 +127,7 @@ spec:
     - name:   "header-name-string"    # required
       value:  "go-template-string"    # required
 
-    realm:            "string"      # optional; defaulti is "{{.metadata.name}}.{{.metadata.namespace}}"
+    realm:            "string"      # optional; default is "{{.metadata.name}}.{{.metadata.namespace}}"
        
     errorResponse:                  # optional
       contentType: "string"           # deprecated; use 'headers' instead


### PR DESCRIPTION
Thanks to @ark3 for pointing out the typo.