### PR TITLE
Add permissions to avoid auth0 auth code error

### DIFF
--- a/reference/idp-support/auth0.md
+++ b/reference/idp-support/auth0.md
@@ -17,6 +17,8 @@ With Auth0 as your IDP, you will need to create an `Application` to handle authe
 4. In your newly created application, click on the Settings tab, add the Domain and Callback URLs for your service and ensure the "Token Endpoint Authentication Method" is set to `Post`. The default YAML installation of Ambassador Pro uses `/callback` for the URL, so the values should be the domain name that points to Ambassador, e.g., `example.com/callback` and `example.com`.
 
   ![](/doc-images/Auth0_none.png)
+  
+  Click Advanced Settings > Grant Types and check "Authorization Code"
 
 5. Update the Auth0 `Filter` and `FilterPolicy`. You can get the `ClientID` and `secret` from your application settings:
 


### PR DESCRIPTION
Without this step auth0 errors with "unauthorized_client: Grant type 'authorization_code' not allowed for the client."