### PR TITLE
Fix typo, 'Customer' → 'Custom'

### DIFF
--- a/reference/config-format.md
+++ b/reference/config-format.md
@@ -2,7 +2,7 @@
 
 Ambassador exposes three methods for configuration.
 
-- [Ambassador Customer Resource Definitions (CRDs)](/reference/core/crds)
+- [Ambassador Custom Resource Definitions (CRDs)](/reference/core/crds)
 - [Kubernetes Service Annotations](/reference/core/annotations)
 - [Kubernetes Ingress Resource](/reference/core/ingress-controller)
 

--- a/reference/core/crds.md
+++ b/reference/core/crds.md
@@ -1,4 +1,4 @@
-# Ambassador Configuration with Customer Resource Definitions (CRDs)
+# Ambassador Configuration with Custom Resource Definitions (CRDs)
 
 As of Ambassador 0.70, any Ambassador resource can be expressed as a CRD in the `getambassador.io` API group:
 


### PR DESCRIPTION
Fix typo whereby CRD was referred to as Customer (instead of Custom) Resource Definition.