### PR TITLE
simplify ingress docs a bit

### DIFF
--- a/reference/core/ingress-controller.md
+++ b/reference/core/ingress-controller.md
@@ -4,7 +4,7 @@ An `Ingress` resource is a popular way to expose Kubernetes services to the Inte
 
 ## When and How to Use the `Ingress` Resource
 
-If you're new to Ambassador and Kubernetes, we'd recommend you start with our [quickstart](/user-guide/getting-started/).
+If you're new to Ambassador and Kubernetes, we'd recommend you start with our [quickstart](/user-guide/getting-started/), instead of using `Ingress`.
 
 If you're a power user and need to integrate with other software that leverages the `Ingress` resource, read on. The `Ingress` specification is very basic, and, as such, does not support many of the features of Ambassador, so you'll be using both `Ingress` resources and `Mapping` resources to manage your Kubernetes services.
 


### PR DESCRIPTION
The ingress docs are a bit confusing, so this is an attempt to simplify them.

They cover a lot of low level technical detail, without explaining why or when. (And they bury they why/when pretty far down in the docs).

So this basically explains why you should care, and then tells everyone to switch to not use it unless they really have to.