### PR TITLE
[early-access] Fix complaints from the broken link checker

### DIFF
--- a/about/alternatives.md
+++ b/about/alternatives.md
@@ -3,7 +3,7 @@
 Alternatives to the Ambassador Edge Stack fall into three basic categories:
 
 * Hosted API gateways, such as the [Amazon API gateway](https://aws.amazon.com/api-gateway/).
-* Traditional API gateways, such as [Kong](https://getkong.org/).
+* Traditional API gateways, such as [Kong](https://konghq.org/).
 * L7 proxies, such as [Traefik](https://traefik.io/), [NGINX](http://nginx.org/), [HAProxy](http://www.haproxy.org/), or [Envoy](https://www.envoyproxy.io), or Ingress controllers built on these proxies.
 
 Both hosted API gateways and traditional API gateways are:

--- a/about/support.md
+++ b/about/support.md
@@ -8,11 +8,11 @@ If you need help deploying Ambassador at your organization, there are several di
 
 If you are running the Ambassador API Gateway or the Ambassador Edge Stack with free, community licenses, [join our Slack channel](http://d6e.co/slack) to talk with other users in the community and get your questions answered.
 
-If you can’t find an answer there, [contact us](https://www.getambassador.io/contact) to learn more about the support options available with Ambassador Edge Stack Enterprise.
+If you can’t find an answer there, [contact us](/contact) to learn more about the support options available with Ambassador Edge Stack Enterprise.
 
 ### Ambassador Edge Stack Enterprise
 
-With Ambassador Edge Stack Enterprise, you have access to deployment and production support. To learn more, [contact sales](https://www.getambassador.io/contact).
+With Ambassador Edge Stack Enterprise, you have access to deployment and production support. To learn more, [contact sales](/contact).
 
 **Deployment and Update Support**: The Ambassador Edge Stack can accelerate your migration to Kubernetes, or your upgrade between versions of Ambassador. Deployment support helps you with the Ambassador Edge Stack and Kubernetes migration, before you move to production.
 
@@ -24,4 +24,4 @@ If you see a bug you want to fix, see room for documentation improvements, or ha
 
 ## Pricing
 
-[Contact us](https://www.getambassador.io/contact) to learn how we can help, and for detailed pricing information.
+[Contact us](/contact) to learn how we can help, and for detailed pricing information.

--- a/concepts/using-ambassador-in-org.md
+++ b/concepts/using-ambassador-in-org.md
@@ -12,7 +12,7 @@ Ambassador Edge Stack can be used for testing services and accelerating continuo
 
 ## Other Applications
 
-Check out the [Resources](https://www.getambassador.io/resources/) section that includes case studies, articles, videos, and strategies for building and using the Ambassador API Gateway, and the Ambassador Edge Stack. 
+Check out the [Resources](/resources/) section that includes case studies, articles, videos, and strategies for building and using the Ambassador API Gateway, and the Ambassador Edge Stack. 
 
 Plus, hear from real people and organizations about how they implemented Ambassador in their company.
 

--- a/reference/idp-support/onelogin.md
+++ b/reference/idp-support/onelogin.md
@@ -43,7 +43,7 @@ Next, configure Ambassador to require authentication with OneLogin, so you must 
 
 Now you must configure your Ambassador instance to use OneLogin.
 
-1. First, create an [OAuth Filter](../../reference/filter-reference#filter-type-oauth2) with the credentials you copied earlier.  
+1. First, create an [OAuth Filter](../../filter-reference#filter-type-oauth2) with the credentials you copied earlier.  
 
 Here is an example YAML:
 
@@ -62,7 +62,7 @@ Here is an example YAML:
         secret: {{Client Secret}}
 ```
 
-2. Next, create a [FilterPolicy](../../reference/filter-reference#filterpolicy-definition) to use the `Filter` you just created.
+2. Next, create a [FilterPolicy](../../filter-reference#filterpolicy-definition) to use the `Filter` you just created.
 
 Some example YAML:
 


### PR DESCRIPTION
Some of these are actual broken links, but some of them are just removing
the leading "https://www.getambassador.io/" from links, as that makes it
hard to distinguish between the deployed website and website previews.