### PR TITLE
[GA] Run a broken link checker from CI

### DIFF
--- a/.ci/blc-website-preview
+++ b/.ci/blc-website-preview
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Datawire. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+set -o errexit
+set -o nounset
+
+if ! [[ -d /tmp/getambassador.io/public ]]; then
+	echo '[blc-website-preview] skipping: website preview was not built'
+	exit 0
+fi
+
+set -o verbose
+
+docs_commit=$(git rev-parse HEAD)
+
+cd /tmp
+git clone https://github.com/datawire/getambassador.io-blc.git
+cd getambassador.io-blc
+npm install
+
+pushd /tmp/getambassador.io/public
+python3 -m http.server 2>/dev/null &
+trap "kill $!" EXIT
+popd
+
+./blc.js http://localhost:8000/ > /tmp/blc.txt
+
+set +o verbose
+num_complaints=$(grep ^Page /tmp/blc.txt | sort -u | wc -l)
+RED=$'\033[1;31m'
+GRN=$'\033[1;32m'
+BLD=$'\033[1m'
+END=$'\033[0m'
+if [[ $num_complaints -eq 0 ]]; then
+	printf "%s======================= 0 broken-link-checker complaints =======================%s\n" "$GRN$BLD" "$END"
+else
+	printf "%s======================= %d broken-link-checker complaints ======================%s\n" "$RED$BLD" $num_complaints "$END$RED"
+	grep ^Page /tmp/blc.txt | sort -u
+	printf "%s====================== end broken-link-checker complaints ======================%s\n" "$RED$BLD" "$END"
+fi
+set -o verbose
+
+# XXX: always mark this as "success" for now, because we still need to
+# land broken-link fixes in a few repos.
+cat >/tmp/github-status.json <<EOF
+{
+  "context": "continuous-integration/broken-link-check",
+  "state": "success",
+  "target_url": "${TRAVIS_JOB_WEB_URL}",
+  "description": "Found ${num_complaints} bad links in the website preview"
+}
+EOF
+
+cat /tmp/github-status.json
+
+curl \
+	-H "Accept: application/json" \
+	-H "Content-Type: application/json" \
+	-X POST \
+	--data '@/tmp/github-status.json' \
+	"https://${GH_TOKEN}@api.github.com/repos/datawire/ambassador-docs/statuses/${TRAVIS_PULL_REQUEST_SHA:-${docs_commit}}"

--- a/.ci/pr-build-website-preview
+++ b/.ci/pr-build-website-preview
@@ -21,7 +21,7 @@ case "${TRAVIS_PULL_REQUEST_SHA:+${TRAVIS_BRANCH:-}}" in
 	master) submodule=content;;
 	early-access) submodule=content-ea/early-access;;
 	*)
-		echo "[pr-build-preview] skipping: not a PR in to 'master' or 'early-access'"
+		echo "[pr-build-website-preview] skipping: not a PR in to 'master' or 'early-access'"
 		exit 0
 		;;
 esac

--- a/.ci/publish-website-preview
+++ b/.ci/publish-website-preview
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 
 if ! [[ -d /tmp/getambassador.io/public ]]; then
-	echo '[publish-preview] skipping: website preview was not built'
+	echo '[publish-website-preview] skipping: website preview was not built'
 	exit 0
 fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,15 @@ env:
 git:
   depth: false
 
+install:
+  - node --version
+  - nvm use 11
+  - node --version
+
 script:
   - ./.ci/pr-build-website-preview
   - ./.ci/publish-website-preview
+  - ./.ci/blc-website-preview
 
 deploy:
   - provider: script


### PR DESCRIPTION
For now, it still allows CI to pass, but posts a status line to GitHub.  After we have this merged and everything is coming back clean, then we can make it mandatory.