### PR TITLE
Have passing the broken-link-checker be mandatory

### DIFF
--- a/.ci/blc-website-preview
+++ b/.ci/blc-website-preview
@@ -51,12 +51,10 @@ else
 fi
 set -o verbose
 
-# XXX: always mark this as "success" for now, because we still need to
-# land broken-link fixes in a few repos.
 cat >/tmp/github-status.json <<EOF
 {
   "context": "continuous-integration/broken-link-check",
-  "state": "success",
+  "state": "$(if [[ $num_complaints -eq 0 ]]; then echo success; else echo failure; fi)",
   "target_url": "${TRAVIS_JOB_WEB_URL}",
   "description": "Found ${num_complaints} bad links in the website preview"
 }


### PR DESCRIPTION
[Now that](https://github.com/datawire/getambassador.io/pull/162) the website docs update [seems to be working](https://github.com/datawire/getambassador.io/commit/180c019daced279b61726fc55af1694d5689cef9), this is now an option.