### PR TITLE
[EA] Comment out 'Debugging' from the sidebar until #179 lands

### DIFF
--- a/doc-links.yml
+++ b/doc-links.yml
@@ -207,8 +207,8 @@
         link: /reference/ambassador-with-aws
       - title: Diagnostics
         link: /reference/diagnostics
-      - title: Debugging
-        link: /reference/debugging  
+      #- title: Debugging
+      #  link: /reference/debugging  
     - title: Plugins
       items:
       - title: Available Plugins


### PR DESCRIPTION
Until #179 lands re-adding the page, it's a 404 link.