### PR TITLE
[GA] Centralize the TRAVIS_COMMIT hacks, also hack around TRAVIS_BRANCH

### DIFF
--- a/.ci/blc-website-preview
+++ b/.ci/blc-website-preview
@@ -24,8 +24,6 @@ fi
 
 set -o verbose
 
-docs_commit=$(git rev-parse HEAD)
-
 cd /tmp
 git clone https://github.com/datawire/getambassador.io-blc.git
 cd getambassador.io-blc
@@ -71,4 +69,4 @@ curl \
 	-H "Content-Type: application/json" \
 	-X POST \
 	--data '@/tmp/github-status.json' \
-	"https://${GH_TOKEN}@api.github.com/repos/datawire/ambassador-docs/statuses/${TRAVIS_PULL_REQUEST_SHA:-${docs_commit}}"
+	"https://${GH_TOKEN}@api.github.com/repos/datawire/ambassador-docs/statuses/${TRAVIS_PULL_REQUEST_SHA:-${TRAVIS_COMMIT}}"

--- a/.ci/pr-build-website-preview
+++ b/.ci/pr-build-website-preview
@@ -21,28 +21,21 @@ case "${TRAVIS_PULL_REQUEST_SHA:+${TRAVIS_BRANCH:-}}" in
 	master) submodule=content;;
 	early-access) submodule=content-ea/early-access;;
 	*)
-		echo "[pr-build-website-preview] skipping: not a PR in to 'master' or 'early-access'"
+		if [[ -z "$TRAVIS_PULL_REQUEST_SHA" ]]; then
+			echo "[pr-build-website-preview] skipping: not a PR"
+		else
+			echo "[pr-build-website-preview] skipping: is a PR, but is in to '${TRAVIS_BRANCH}', not 'master' or 'early-access'"
+		fi
 		exit 0
 		;;
 esac
 
-set -o verbose
-
-# Don't trust $TRAVIS_COMMIT, use $(git rev-parse HEAD) instead.
-#
-# For PRs, it's often set to a stale merge commit that isn't fetched,
-# instead of the actual commit pointed to by refs/pull/NNN/merge which
-# is checked out.  For example, on
-# <https://travis-ci.org/datawire/ambassador-docs/builds/629117603>,
-# the webui says         it's testing commit cb8dc0029465119ada1ee9222539c825f5a7c015,
-# and TRAVIS_COMMIT says it's testing commit cb8dc0029465119ada1ee9222539c825f5a7c015,
-# but in fact            it's testing commit d23659347cd125267b079f2f7900c3e1b032ea4b.
-docs_commit=$(git rev-parse HEAD)
+set -o xtrace
 
 rm -rf /tmp/getambassador.io
 git clone https://d6e-automaton:${GH_TOKEN}@github.com/datawire/getambassador.io.git /tmp/getambassador.io
 cd /tmp/getambassador.io
 git submodule update --init --reference="$TRAVIS_BUILD_DIR"
-git -C "$submodule" checkout "$docs_commit"
+git -C "$submodule" checkout "$TRAVIS_COMMIT"
 npm install
 npm run build

--- a/.ci/publish-website-preview
+++ b/.ci/publish-website-preview
@@ -24,8 +24,6 @@ fi
 
 set -o verbose
 
-docs_commit=$(git rev-parse HEAD)
-
 npm install netlify-cli -g
 
 netlify deploy \
@@ -50,4 +48,4 @@ curl \
 	-H "Content-Type: application/json" \
 	-X POST \
 	--data '@/tmp/github-status.json' \
-	"https://${GH_TOKEN}@api.github.com/repos/datawire/ambassador-docs/statuses/${TRAVIS_PULL_REQUEST_SHA:-${docs_commit}}"
+	"https://${GH_TOKEN}@api.github.com/repos/datawire/ambassador-docs/statuses/${TRAVIS_PULL_REQUEST_SHA:-${TRAVIS_COMMIT}}"

--- a/.ci/travis-fix-env
+++ b/.ci/travis-fix-env
@@ -1,0 +1,25 @@
+#!/hint/sh
+
+# Don't trust $TRAVIS_COMMIT, use $(git rev-parse HEAD) instead.
+#
+# For PRs, it's often set to a stale merge commit that isn't fetched,
+# instead of the actual commit pointed to by refs/pull/NNN/merge which
+# is checked out.  For example, on
+# <https://travis-ci.org/datawire/ambassador-docs/builds/629117603>,
+# the webui says         it's testing commit cb8dc0029465119ada1ee9222539c825f5a7c015,
+# and TRAVIS_COMMIT says it's testing commit cb8dc0029465119ada1ee9222539c825f5a7c015,
+# but in fact            it's testing commit d23659347cd125267b079f2f7900c3e1b032ea4b.
+original_TRAVIS_COMMIT=$TRAVIS_COMMIT
+TRAVIS_COMMIT=$(git rev-parse HEAD)
+echo "adjusted TRAVIS_COMMIT : ${original_TRAVIS_COMMIT} -> ${TRAVIS_COMMIT}"
+
+# Don't trust $TRAVIS_BRANCH for PRs; it can be wrong in the same way
+# that $TRAVIS_COMMIT is wrong.
+#
+# For example: https://travis-ci.org/datawire/ambassador-docs/builds/632583559
+if [ -n "$TRAVIS_PULL_REQUEST_SHA" ]; then
+	original_TRAVIS_BRANCH=$TRAVIS_BRANCH
+	# Resolve the "multiple branches" question by limiting to just "master" or "early-access".
+	TRAVIS_BRANCH=$(git show-ref | awk -vcommit="$(git rev-parse "$TRAVIS_COMMIT^")" '$1 == commit && $2 ~ /^refs\/remotes\/origin\/(master|early-access)$/ { sub("refs/remotes/origin/", ""); print $2; exit; }')
+	echo "adjusted TRAVIS_BRANCH : ${original_TRAVIS_BRANCH} -> ${TRAVIS_BRANCH}"
+fi

--- a/.ci/travis-fix-env
+++ b/.ci/travis-fix-env
@@ -19,7 +19,22 @@ echo "adjusted TRAVIS_COMMIT : ${original_TRAVIS_COMMIT} -> ${TRAVIS_COMMIT}"
 # For example: https://travis-ci.org/datawire/ambassador-docs/builds/632583559
 if [ -n "$TRAVIS_PULL_REQUEST_SHA" ]; then
 	original_TRAVIS_BRANCH=$TRAVIS_BRANCH
-	# Resolve the "multiple branches" question by limiting to just "master" or "early-access".
+	# Because this is for a PR, `$TRAVIS_COMMIT` is a synthesized merge-commit with 2 parents.  The first
+	# parent (which is given by `$TRAVIS_COMMIT^`) is the target branch, and the second parent is the PR
+	# branch.
+	#
+	# So, we need to look at `$TRAVIS_COMMIT^` and decide which remote tracking branch that corresponds
+	# to.  Sounds like a job for `git describe`... except that `git describe` has mind-bogglingly poor
+	# options for selecting which refs to consider.  Instead, we'll do this ourselves with awk by parsing
+	# `git show-ref`.
+	#
+	# The output of `git show-ref` looks like
+	#     4e206c51ef558f83d5c67e4586279e1ea15cdda2 refs/heads/master
+	#     4e206c51ef558f83d5c67e4586279e1ea15cdda2 refs/remotes/origin/HEAD
+	#     c8d4e9a3579e45cfefdc3374de8f0e9b3c956ad0 refs/remotes/origin/early-access
+	#     4e206c51ef558f83d5c67e4586279e1ea15cdda2 refs/remotes/origin/master
+	#
+	# Resolve the "what if multiple refs match" question by limiting to just "master" or "early-access".
 	TRAVIS_BRANCH=$(git show-ref | awk -vcommit="$(git rev-parse "$TRAVIS_COMMIT^")" '$1 == commit && $2 ~ /^refs\/remotes\/origin\/(master|early-access)$/ { sub("refs/remotes/origin/", ""); print $2; exit; }')
 	echo "adjusted TRAVIS_BRANCH : ${original_TRAVIS_BRANCH} -> ${TRAVIS_BRANCH}"
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
   - node --version
   - nvm use 11
   - node --version
+  - source ./.ci/travis-fix-env
 
 script:
   - ./.ci/pr-build-website-preview


### PR DESCRIPTION
I knew that TRAVIS_COMMIT couldn't be trusted; apparently TRAVIS_BRANCH can't be trusted either.  I became aware of this because of the really weird failure that is https://travis-ci.org/datawire/ambassador-docs/builds/632583559 (on PR #194).