### PR TITLE
Add Edge Control in CI to docs and fix broken stuff

### DIFF
--- a/doc-links.yml
+++ b/doc-links.yml
@@ -157,6 +157,8 @@
       items: 
         - title: Edge Control Installation
           link: /reference/edge-control
+        - title: Edge Control in CI
+          link: /reference/edge-control-in-ci
     - title: Developer Portal
       link: /reference/dev-portal
     - title: Configuring Kubernetes Services

--- a/reference/edge-control-in-ci.md
+++ b/reference/edge-control-in-ci.md
@@ -24,13 +24,14 @@ The CI job that performs system tests of MyService would look roughly like this
    CI_TAG="MyService-$(git describe --always --tags)"
    edgectl intercept add MyService -n "$CI_TAG" -m "x-ci-tag=$CI_TAG" -t localhost:9000
    ```
-6. Run system tests by injecting requests into the application with the appropriate header set
+6. Run system tests by sending requests to the application with the appropriate header set
    ```console
    curl "$API_GATEWAY" -H "x-ci-tag:$CI_TAG"
    # (or)
    env "TEST_HEADER_VALUE=$CI_TAG" pytest ...
    # (etc)
    ```
+   These requests will go to your shared cluster just as any request would, but calls to MyService from within the application will be routed back to the modified version running in CI because the intercepted header is set appropriately. All other calls to MyService will function as usual, going to the version of MyService running in the cluster.
 7. Delete the intercept when the job is done. This is not strictly necessary, as the Traffic Manager will clean up automatically after a while, but doing so here keeps diagnostic output (`edgectl intercept list`, etc.) clean.
    ```console
    edgectl intercept remove "$CI_TAG"

--- a/reference/edge-control-in-ci.md
+++ b/reference/edge-control-in-ci.md
@@ -1,0 +1,37 @@
+# Edge Control in CI
+
+Imagine you have an application consisting of a hundred microservices and you want to test microservice changes in CI before release. One approach to running such a test would be to spin up a new cluster, install and launch your application in that cluster, replace the one microservice that you wish to test, and run your tests against that cluster. This would work, but it's complicated, expensive, and slow.
+
+If you could use one persistent cluster and application for every test, you would avoid the costs of spinning up a new cluster and installing your application every time. The Telepresence swap deployment workflow lets you do this. Each test run can swap the existing microservice with the modified version running in CI, run tests against the cluster, and then terminate the swap to restore things for the next test. The downside of swap deployment is that the entire cluster is affected, which means that a robust testing strategy must run tests sequentially without overlap. If changes come in fast and test runs are slow, your CI system will fall behind and become the bottleneck.
+
+To avoid this bottleneck, your CI system must be able to test different changesets concurrently without tests interfering with one another. The outbound and intercept features of Edge Control make this possible. The key requirements are
+
+- the microservice being tested must be an HTTP service, and
+- it must be possible to set a test-run-specific HTTP header for requests to the microservice being tested. Ideally that header would pass through from where requests enter the system all the way to the microservice being tested.
+
+The CI job that performs system tests of MyService would look roughly like this
+
+1. Install the required software (`edgectl`, `kubectl`, etc.).
+2. Perform the usual CI steps (build the microservice and perform unit/local tests).
+3. Set up access to the shared cluster, so that e.g., `kubectl get pods` talks to right place.
+4. Launch the Edge Control Daemon and connect to the cluster
+   ```console
+   sudo edgectl daemon
+   edgectl connect
+   ```
+5. Add an intercept specific to this test session, e.g., using commit information to construct a unique name
+   ```console
+   CI_TAG="MyService-$(git describe --always --tags)"
+   edgectl intercept add MyService -n "$CI_TAG" -m "x-ci-tag=$CI_TAG" -t localhost:9000
+   ```
+6. Run system tests by injecting requests into the application with the appropriate header set
+   ```console
+   curl "$API_GATEWAY" -H "x-ci-tag:$CI_TAG"
+   # (or)
+   env "TEST_HEADER_VALUE=$CI_TAG" pytest ...
+   # (etc)
+   ```
+7. Delete the intercept when the job is done. This is not strictly necessary, as the Traffic Manager will clean up automatically after a while, but doing so here keeps diagnostic output (`edgectl intercept list`, etc.) clean.
+   ```console
+   edgectl intercept remove "$CI_TAG"
+   ```

--- a/reference/edge-control.md
+++ b/reference/edge-control.md
@@ -35,20 +35,22 @@ chmod a+x edgectl
 mv edgectl ~/bin  # Somewhere in your PATH
 ```
 
- Note: Similar instructions work for Windows:
+Note: Similar instructions work for Windows:
 
-    ```
-    curl -fLO https://metriton.datawire.io/downloads/windows/edgectl.exe
-    mv edgectl.exe C:\windows\  # Somewhere in your PATH
-    ```
+```bash
+curl -fLO https://metriton.datawire.io/downloads/windows/edgectl.exe
+mv edgectl.exe C:\windows\  # Somewhere in your PATH
+```
 
-    but Edge Control’s cluster features, as described in this document, do not work correctly on Windows at this time.
+but Edge Control’s cluster features, as described in this document, do not work correctly on Windows at this time.
 
-    Note: You can build Edge Control from source, but the straightforward way
+Note: You can build Edge Control from source, but the straightforward way
 
-   `GO111MODULE=on go get github.com/datawire/ambassador/cmd/edgectl`
+```bash
+GO111MODULE=on go get github.com/datawire/ambassador/cmd/edgectl`
+```
 
-    leaves you with a binary that has no embedded version number. If you really want to build from source, clone the repository and run `./builder/build_push_cli.sh build`, which will leave a binary in the `~/bin directory`. We will have a better answer for building from source soon.
+leaves you with a binary that has no embedded version number. If you really want to build from source, clone the repository and run `./builder/build_push_cli.sh build`, which will leave a binary in the `~/bin directory`. We will have a better answer for building from source soon.
 
 2. Launch the daemon component using sudo
 
@@ -74,7 +76,7 @@ The daemon’s logging output may be found in `/tmp/edgectl.log`.
 
 Tell the running daemon to exit with:
 
-```
+```bash
 $ edgectl quit
 Edge Control Daemon quitting...
 ```
@@ -140,7 +142,7 @@ spec:
 
 4. Apply them:
 
-```yaml
+```bash
 $ kubectl apply -f traffic-manager.yaml
 service/telepresence-proxy created
 deployment.apps/telepresence-proxy created
@@ -150,7 +152,7 @@ deployment.apps/telepresence-proxy created
 
 Any microservice running in a cluster with a traffic manager can opt in to intercept functionality by including the traffic agent in its pods. The following manifests represent a simple microservice.
 
-````yaml
+```yaml
 # This is hello.yaml
 ---
 apiVersion: v1
@@ -188,7 +190,7 @@ spec:
           image: datawire/hello-world:latest
           ports:
             - containerPort: 8000   # Application port
-````
+```
 
 Here is a modified set of manifests that includes the traffic agent.
 
@@ -324,7 +326,7 @@ deployment.apps/hello configured
 
 2. Launch a local service on your laptop. If you were debugging the hello service, you might run a local copy in your debugger. In this example, we will start an arbitrary service on port 9000.
 
-```python
+```bash
 $ # using Python
 
 $ python3 -m http.server 9000
@@ -364,46 +366,45 @@ Hello, world!
 4. Set up an intercept. In this example, we’ll capture requests that have the x-dev header set to $USER.
 
 ```bash
-    $ edgectl intercept avail
-    Found 1 interceptable deployment(s):
-        1. hello
+$ edgectl intercept avail
+Found 1 interceptable deployment(s):
+    1. hello
 
-    $ edgectl intercept list
-    No intercepts
+$ edgectl intercept list
+No intercepts
 
-    $ edgectl intercept add hello -n example -m x-dev=$USER -t localhost:9000
-    Added intercept "example"
+$ edgectl intercept add hello -n example -m x-dev=$USER -t localhost:9000
+Added intercept "example"
 
-    $ edgectl intercept list
-    1. example
-        Intercepting requests to hello when
-        - x-dev: ark3
-        and redirecting them to localhost:9000
+$ edgectl intercept list
+1. example
+    Intercepting requests to hello when
+    - x-dev: ark3
+    and redirecting them to localhost:9000
 
-    $ curl hello
-    Hello, world!
+$ curl hello
+Hello, world!
 
-    $ curl hello -H x-dev:$USER
-    <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
-    <html>
-    <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <title>Directory listing for /</title>
-    </head>
-    <body>
-    <h1>Directory listing for /</h1>
-    <hr>
-    <ul>
-    </ul>
-    <hr>
-    </body>
-    </html>
+$ curl hello -H x-dev:$USER
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<title>Directory listing for /</title>
+</head>
+<body>
+<h1>Directory listing for /</h1>
+<hr>
+<ul>
+</ul>
+<hr>
+</body>
+</html>
 ```
 
 As you can see, the second request, which includes the specified x-dev header, is served by the local server.
 
 5. Next, remove the intercept to restore normal operation.
-
 
 ```bash
 $ edgectl intercept remove example


### PR DESCRIPTION
A lot of the formatting of the original document was lost or destroyed in the transition from markdown to... markdown? I don't know what happened, but I patched up the worst of it. The original page needs a lot more work, but I don't have time at this moment. More importantly, this PR adds the Edge Control in CI docs, which could stand some iteration but may be ready to go.