### PR TITLE
Fixing typo in module example

### DIFF
--- a/user-guide/tracing-tutorial-datadog.md
+++ b/user-guide/tracing-tutorial-datadog.md
@@ -22,7 +22,8 @@ When using JSON logging with Envoy, Ambassador will automatically append the `dd
 ---
 apiVersion: getambassador.io/v1
 kind: Module
-name: ambassador
+metadata:
+  name: ambassador
 config:
   envoy_log_type: json
 ```


### PR DESCRIPTION
From https://github.com/datawire/ambassador/pull/1968:

Module was created incorrectly such that it would not deploy into kubernetes as the name was set incorrectly. I have added the correct syntax for it to install into kubernetes.