### PR TITLE
Always pass -L to curl [apro #734]

### DIFF
--- a/about/quickstart.md
+++ b/about/quickstart.md
@@ -29,7 +29,7 @@ Since Ambassador Edge Stack is a comprehensive, self-service edge stack, its pri
 in your browser, or from the command line as
 
 ```shell
-curl 'http://localhost:8080/qotm/?json=true'
+curl -L 'http://localhost:8080/qotm/?json=true'
 ```
 
 This request will route to the `qotm` service at `demo.getambassador.io`, and return a random quote for this very moment.
@@ -47,13 +47,13 @@ You saw above that access to the diagnostic overview required you to authenticat
 in your brower. From the command line, you can see that 
 
 ```shell
-curl -v 'http://localhost:8080/qotm/quote/5?json=true'
+curl -Lv 'http://localhost:8080/qotm/quote/5?json=true'
 ```
 
 will return a 401, but
 
 ```shell
-curl -v -u username:password 'http://localhost:8080/qotm/quote/5?json=true'
+curl -Lv -u username:password 'http://localhost:8080/qotm/quote/5?json=true'
 ```
 
 will succeed. (Note that that's literally "username" and "password" -- the demo auth service is deliberately not very secure!)

--- a/docs/guides/filter-dev-guide.md
+++ b/docs/guides/filter-dev-guide.md
@@ -73,7 +73,7 @@ Now, you can quickly test and develop your filter.
 2. Test the filter by running `curl`:
 
     ```
-    $ curl -v localhost:8080?db=2
+    $ curl -Lv localhost:8080?db=2
     * Rebuilt URL to: localhost:8080/?db=2
     *   Trying ::1...
     * TCP_NODELAY set

--- a/reference/edge-control-in-ci.md
+++ b/reference/edge-control-in-ci.md
@@ -26,7 +26,7 @@ The CI job that performs system tests of MyService would look roughly like this
    ```
 6. Run system tests by sending requests to the application with the appropriate header set
    ```console
-   curl "$API_GATEWAY" -H "x-ci-tag:$CI_TAG"
+   curl -L -H "x-ci-tag:$CI_TAG" "$API_GATEWAY"
    # (or)
    env "TEST_HEADER_VALUE=$CI_TAG" pytest ...
    # (etc)

--- a/reference/edge-control.md
+++ b/reference/edge-control.md
@@ -294,7 +294,7 @@ Connected
   Proxy:         ON (networking to the cluster is enabled)
   Intercepts:    Unavailable: no traffic manager
 
-$ curl hello
+$ curl -L hello
 Hello, world!
 ```
 
@@ -359,7 +359,7 @@ Connected
   Interceptable: 1 deployments
   Intercepts:    0 total, 0 local
 
-$ curl hello
+$ curl -L hello
 Hello, world!
 ```
 
@@ -382,10 +382,10 @@ $ edgectl intercept list
     - x-dev: ark3
     and redirecting them to localhost:9000
 
-$ curl hello
+$ curl -L hello
 Hello, world!
 
-$ curl hello -H x-dev:$USER
+$ curl -L -H x-dev:$USER hello
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html>
 <head>
@@ -410,7 +410,7 @@ As you can see, the second request, which includes the specified x-dev header, i
 $ edgectl intercept remove example
 Removed intercept "example"
 
-$ curl hello -H x-dev:$USER
+$ curl -L -H x-dev:$USER hello
 Hello, world!
 ```
 

--- a/user-guide/auth-tutorial.md
+++ b/user-guide/auth-tutorial.md
@@ -124,7 +124,7 @@ Note that the cluster does not yet contain any Ambassador Edge Stack AuthService
 If we `curl` to a protected URL:
 
 ```shell
-$ curl -v $AMBASSADORURL/backend/get-quote/
+$ curl -Lv $AMBASSADORURL/backend/get-quote/
 ```
 
 We get a 401, since we haven't authenticated.
@@ -149,7 +149,7 @@ We get a 401, since we haven't authenticated.
 If we authenticate to the service, we will get a quote successfully:
 
 ```shell
-$ curl -v -u username:password $AMBASSADORURL/backend/get-quote/
+$ curl -Lv -u username:password $AMBASSADORURL/backend/get-quote/
 
 * TCP_NODELAY set
 * Connected to 54.165.128.189 (54.165.128.189) port 32281 (#0)

--- a/user-guide/consul.md
+++ b/user-guide/consul.md
@@ -135,7 +135,7 @@ Save the above YAML to a file named `qotm-mapping.yaml`, and use `kubectl apply 
 4. Send a request to the `qotm-consul` API.
 
    ```shell
-   curl http://$AMBASSADOR_IP/qotm-consul/
+   curl -L http://$AMBASSADOR_IP/qotm-consul/
 
    {"hostname":"qotm-749c675c6c-hq58f","ok":true,"quote":"The last sentence you read is often sensible nonsense.","time":"2019-03-29T22:21:42.197663","version":"1.7"}
    ```
@@ -235,7 +235,7 @@ This will install into your cluster:
 5. Send a request to the `/qotm-consul-tls/` API.
 
    ```
-   curl $AMBASSADOR_IP/qotm-consul-tls/
+   curl -L $AMBASSADOR_IP/qotm-consul-tls/
 
    {"hostname":"qotm-6c6dc4f67d-hbznl","ok":true,"quote":"A principal idea is omnipresent, much like candy.","time":"2019-04-17T19:27:54.758361","version":"1.7"}
    ```

--- a/user-guide/install.md
+++ b/user-guide/install.md
@@ -134,10 +134,10 @@ In a typical configuration workflow, Custom Resource Definitions (CRDs) are used
 
 4. Apply the configuration to the cluster by typing the command `kubectl apply -f quote-backend.yaml`.
 
-5. Test the configuration by typing `curl -k https://<hostname>/backend/` or `curl -k https://<IP address>/backend/`. You should see something similar to the following:
+5. Test the configuration by typing `curl -Lk https://<hostname>/backend/` or `curl -Lk https://<IP address>/backend/`. You should see something similar to the following:
 
    ```
-   (⎈ |rdl-1:default)$ curl -k https://aes.ri.k36.net/backend/
+   (⎈ |rdl-1:default)$ curl -Lk https://aes.ri.k36.net/backend/
    {
     "server": "idle-cranberry-8tbb6iks",
     "quote": "Non-locality is the driver of truth. By summoning, we vibrate.",

--- a/user-guide/knative.md
+++ b/user-guide/knative.md
@@ -95,7 +95,7 @@ The Ambassador Edge Stack can watch for changes in Knative configuration in your
     We can now use this value and the `EXTERNAL-IP` of Ambassador Edge Stack's Kubernetes service to route to the application:
 
     ```
-    curl -H “Host: helloworld-go.default.example.com” <ambassador IP>
+    curl -L -H "Host: helloworld-go.default.example.com" <ambassador IP>
     ```
 
 We have now installed Knative with Ambassador Edge Stack handling traffic to our serverless applications. See the [Knative documentation](https://knative.dev/docs/) for more information on what else Knative can do.

--- a/user-guide/linkerd2.md
+++ b/user-guide/linkerd2.md
@@ -155,7 +155,7 @@ to apply this configuration to your Kubernetes cluster. Note that in the above c
 1. Send a request to the `qotm-Linkerd2` API.
 
    ```shell
-   curl http://$AMBASSADOR_IP/qotm-Linkerd2/
+   curl -L http://$AMBASSADOR_IP/qotm-Linkerd2/
 
    {"hostname":"qotm-749c675c6c-hq58f","ok":true,"quote":"The last sentence you read is often sensible nonsense.","time":"2019-03-29T22:21:42.197663","version":"1.7"}
    ```

--- a/user-guide/rate-limiting-tutorial.md
+++ b/user-guide/rate-limiting-tutorial.md
@@ -163,7 +163,7 @@ Ambassador Edge Stack would also perform multiple requests to `example-rate-limi
 If we `curl` to a rate-limited URL:
 
 ```shell
-$ curl -v -H "x-ambassador-test-allow: probably" $AMBASSADORURL/backend/
+$ curl -Lv -H "x-ambassador-test-allow: probably" $AMBASSADORURL/backend/
 ```
 
 We get a 429, since we are limited.
@@ -177,7 +177,7 @@ content-length: 0
 If we set the correct header value to the service request, we will get a quote successfully:
 
 ```shell
-$ curl -v -H "x-ambassador-test-allow: true" $AMBASSADORURL/backend/
+$ curl -Lv -H "x-ambassador-test-allow: true" $AMBASSADORURL/backend/
 
 TCP_NODELAY set
 * Connected to 35.196.173.175 (35.196.173.175) port 80 (#0)

--- a/user-guide/tls-termination.md
+++ b/user-guide/tls-termination.md
@@ -97,7 +97,7 @@ If the output to the `kubectl` command is not similar to the example above, edit
 After verifying Ambassador Edge Stack is listening on port 443, send a request to your backend service with curl:
 
 ```
-curl -k https://{{AMBASSADOR_IP}}/backend/
+curl -Lk https://{{AMBASSADOR_IP}}/backend/
 
 {
     "server": "trim-kumquat-fccjxh8x",

--- a/user-guide/tracing-tutorial-datadog.md
+++ b/user-guide/tracing-tutorial-datadog.md
@@ -49,7 +49,7 @@ spec:
 Use `curl` to generate a few requests to an existing Ambassador Edge Stack mapping. You may need to perform many requests since only a subset of random requests are sampled and instrumented with traces.
 
 ```shell
-$ curl $AMBASSADOR_IP/httpbin/ip
+$ curl -L $AMBASSADOR_IP/httpbin/ip
 ```
 
 ## 5. Test traces

--- a/user-guide/tracing-tutorial-zipkin.md
+++ b/user-guide/tracing-tutorial-zipkin.md
@@ -75,7 +75,7 @@ $ kubectl apply -f zipkin.yaml
 Use `curl` to generate a few requests to an existing Ambassador Edge Stack mapping. You may need to perform many requests since only a subset of random requests are sampled and instrumented with traces.
 
 ```shell
-$ curl $AMBASSADOR_IP/httpbin/ip
+$ curl -L $AMBASSADOR_IP/httpbin/ip
 ```
 
 ## 3. Test traces

--- a/user-guide/with-istio.md
+++ b/user-guide/with-istio.md
@@ -73,7 +73,7 @@ Above we see that external IP assigned to our LoadBalancer is 35.224.41.XX (XX i
 You can test if the Ambassador Edge Stack has been installed correctly by using the test route to `httpbin.org` to get the external cluster [Origin IP](https://httpbin.org/ip) from which the request was made:
 
 ```shell
-$ curl 35.224.41.XX/httpbin/ip
+$ curl -L 35.224.41.XX/httpbin/ip
 {
   "origin": "35.192.109.XX"
 }
@@ -81,7 +81,7 @@ $ curl 35.224.41.XX/httpbin/ip
 
 If you're seeing a similar response, then everything is working great!
 
-(Bonus: If you want to use a little bit of awk magic to export the LoadBalancer IP to a variable AMBASSADOR_IP, then you can type `export AMBASSADOR_IP=$(kubectl get services ambassador | tail -1 | awk '{ print $4 }')` and use `curl $AMBASSADOR_IP/httpbin/ip`
+(Bonus: If you want to use a little bit of awk magic to export the LoadBalancer IP to a variable AMBASSADOR_IP, then you can type `export AMBASSADOR_IP=$(kubectl get services ambassador | tail -1 | awk '{ print $4 }')` and use `curl -L $AMBASSADOR_IP/httpbin/ip`
 
 2. Now you are going to modify the bookinfo demo `bookinfo.yaml` manifest to include the necessary Ambassador annotations. See below.
 


### PR DESCRIPTION
As a rule, always pass `-L` to `curl` to have it follow redirects.  The
big motivation for this is that we now redirect from plain http:// to
https:// in a buncha scenarios, which means a lot of the `curl` examples
are wrong.  And adding `-L` shouldn't ever break what we're demonstrating;
so I just added it to all of the commands (even those that already say
https://) to avoid thinking about it too much and spending more time on
it.

And while I'm at it, fix “curly quotes” being used instead of "stright
quotes" in a command example in knative.md; since the change had me
looking at that line anyway.  (Likely introduced by macOS automatically
doing curly quotes by default...)