### PR TITLE
Increase aes.yaml timeout as well

### DIFF
--- a/user-guide/install.md
+++ b/user-guide/install.md
@@ -20,7 +20,7 @@ The Ambassador Edge Stack is typically deployed to Kubernetes from the command l
     kubectl apply -f https://www.getambassador.io/early-access/yaml/aes-crds.yaml && \
     kubectl wait --for condition=established --timeout=90s crd -lproduct=aes && \
     kubectl apply -f https://www.getambassador.io/early-access/yaml/aes.yaml && \
-    kubectl -n ambassador wait --for condition=available --timeout=60s deploy -lproduct=aes
+    kubectl -n ambassador wait --for condition=available --timeout=90s deploy -lproduct=aes
     ```
 
 2. Determine the IP address of your cluster by running the following command:


### PR DESCRIPTION
In #177 we had increased the timeout for our CRDs, but not for the bigger and heavier aes.yaml file which is the actual bottleneck and reason for timeouts. This PR increases that timeout to 90s as well.