### PR TITLE
Mention the new behavior for default namespace resolution with 1.0.0 [apro #733]

### DIFF
--- a/reference/mappings.md
+++ b/reference/mappings.md
@@ -190,7 +190,7 @@ Where everything except for the `service` is optional.
 
 - `scheme` can be either `http` or `https`; if not present, the default is `http`.
 - `service` is the name of a service (typically the service name in Kubernetes or Consul); it is not allowed to contain the `.` character.
-- `namespace` is the namespace in which the service is running. If not supplied, it defaults to the namespace in which Ambassador Edge Stack is running. When using a Consul resolver, `namespace` is not allowed.
+- `namespace` is the namespace in which the service is running. Starting with Ambassador 1.0.0, if not supplied, it defaults to the namespace in which the Mapping resource is defined. The default behavior can be configured using the [`ambassador` Module](../core/ambassador). When using a Consul resolver, `namespace` is not allowed.
 - `port` is the port to which a request should be sent. If not specified, it defaults to `80` when the scheme is `http` or `443` when the scheme is `https`. Note that the [resolver](../core/resolvers) may return a port in which case the `port` setting is ignored.
 
 Note that while using `service.namespace.svc.cluster.local` may work for Kubernetes resolvers, the preferred syntax is `service.namespace`.


### PR DESCRIPTION
I noticed somebody referencing this documentation item on OSS Slack and wanted to make sure the description was updated with 1.0.0 as a complement to https://github.com/datawire/ambassador/pull/2141/files

Ref. to the Slack discussion that triggered this: https://datawire-oss.slack.com/archives/CAULN7S76/p1578781978097800