### PR TITLE
Initial docs for LogService

### DIFF
--- a/aes-pages.yml
+++ b/aes-pages.yml
@@ -52,6 +52,7 @@
 - /reference/running
 - /reference/services/access-control
 - /reference/services/auth-service
+- /reference/services/log-service
 - /reference/services/rate-limit-service
 - /reference/services/services
 - /reference/services/tracing-service

--- a/api-gateway-pages.yml
+++ b/api-gateway-pages.yml
@@ -34,6 +34,7 @@
 - /reference/rewrites
 - /reference/running
 - /reference/services/auth-service
+- /reference/services/log-service
 - /reference/services/rate-limit-service
 - /reference/services/services
 - /reference/services/tracing-service

--- a/doc-links.yml
+++ b/doc-links.yml
@@ -209,6 +209,8 @@
         link: /reference/services/access-control
       - title: AuthService Plugin
         link: /reference/services/auth-service
+      - title: Log Plugin
+        link: /reference/services/log-service
       - title: RateLimtingService Plugin
         link: /reference/services/rate-limit-service
       - title: TracingService Plugin

--- a/reference/configuration.md
+++ b/reference/configuration.md
@@ -16,7 +16,7 @@ The Ambassador Edge Stack is configured in a declarative fashion, using YAML man
 
 - [`Ingress`](../core/ingress-controller) manifests allows you to use Ambassador as a Kubernetes ingress controller. See the provided documention on configuration with Ambassador, and review the [Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/) for detailed information on the `Ingress` resource.
 
-- `LogService`manifests help you configure logging. See [Kubernertes Logging Architecture](https://kubernetes.io/docs/concepts/cluster-administration/logging/) for more details.
+- [`LogService`](../services/log-service) manifests configure centralized access logging.
 
 - [`TCPMapping`](../tcpmappings) manifests associate TCP mappings with Kubernetes services.
 

--- a/reference/overview.md
+++ b/reference/overview.md
@@ -67,6 +67,7 @@ The Reference section provides detailed information on configuring and managing 
 * [Available Plugins](../../reference/services/services)
 * [FilterPolicy Plugin for Access Control](../../reference/services/access-control)
 * [AuthService Plugin](../../reference/services/auth-service)
+* [LogService Plugin](../../reference/services/log-service)
 * [RateLimtingService Plugin](../../reference/services/rate-limit-service)
 * [TracingService Plugin](../../reference/services/tracing-service)
 

--- a/reference/services/log-service.md
+++ b/reference/services/log-service.md
@@ -1,0 +1,39 @@
+# LogService Plugin
+
+By default, Ambassador Edge Stack puts the access logs on stdout; such
+that the can be read using `kubectl logs`.  The format of those logs,
+and the local destination of them, can be configured using the
+[`envoy_log_` settings in the `ambassador
+Module`](../../core/ambassador#the-ambassador-module).  However, the
+options there only allow for logging local to Ambassador's Pod.  By
+configuring a `LogService`, you can configure Ambassador Edge Stack to
+report its access logs to a remote service.
+
+The remote access log service (or ALS) must implement the
+`AccessLogService` gRPC interface, defined in [Envoy's `als.proto`][als.proto].
+
+[als.proto]: https://github.com/datawire/ambassador/blob/master/api/envoy/service/accesslog/v2/als.proto
+
+```yaml
+---
+apiVersion: getambassador.io/v2
+kind: LogService
+metadata:
+  name: example-log-service
+spec:
+  ambassador_id:           # optional; default is ["default"]
+  - "string"
+  ambassador_id: "string"  # no need for a list if there's only one value
+
+  service: "string"                 # required
+  driver: "enum-string:[tcp, http]" # required
+  driver_config:                    # required
+    additional_log_headers:         # optional; default is [] (only for `driver: http`)
+    - header_name: string           # required
+      during_request: boolean       # optional; default is true
+      during_response: boolean      # optional; default is true
+      during_trailer: boolean       # optional; default is true
+  flush_interval_time: integer      # optional; default is 1
+  flush_interval_byte_size: integer # optional; default is 16384
+  grpc: boolean                     # optional; default is false
+```

--- a/reference/services/log-service.md
+++ b/reference/services/log-service.md
@@ -7,7 +7,8 @@ and the local destination of them, can be configured using the
 Module`](../../core/ambassador#the-ambassador-module).  However, the
 options there only allow for logging local to Ambassador's Pod.  By
 configuring a `LogService`, you can configure Ambassador Edge Stack to
-report its access logs to a remote service.
+report its access logs to a remote service, in addition to the usual
+`ambassador Module` configured logging.
 
 The remote access log service (or ALS) must implement the
 `AccessLogService` gRPC interface, defined in [Envoy's `als.proto`][als.proto].

--- a/reference/services/log-service.md
+++ b/reference/services/log-service.md
@@ -28,12 +28,53 @@ spec:
   service: "string"                 # required
   driver: "enum-string:[tcp, http]" # required
   driver_config:                    # required
-    additional_log_headers:         # optional; default is [] (only for `driver: http`)
-    - header_name: string           # required
-      during_request: boolean       # optional; default is true
-      during_response: boolean      # optional; default is true
-      during_trailer: boolean       # optional; default is true
-  flush_interval_time: integer      # optional; default is 1
+    additional_log_headers:           # optional; default is [] (only for `driver: http`)
+    - header_name: string               # required
+      during_request: boolean           # optional; default is true
+      during_response: boolean          # optional; default is true
+      during_trailer: boolean           # optional; default is true
+  flush_interval_time: int-seconds  # optional; default is 1
   flush_interval_byte_size: integer # optional; default is 16384
   grpc: boolean                     # optional; default is false
+```
+
+ - `service` is where to route the access log gRPC requests to
+ - `driver` identifies which type of accesses to log; HTTP requests (`"http"`) or
+   TLS connections (`"tcp"`).
+ - `driver_config` stores the configuration that is specific to the `driver`:
+    * `driver: tcp` has no additional configuration; the config must
+      be set as `driver_config: {}`.
+    * `driver: http`
+	  - `additional_log_headers` identifies HTTP headers to include in
+        the access log, and when in the logged-request's lifecycle to
+        include them.
+ - `flush_interval_time` is the maximum number of seconds to buffer
+   accesses for before sending them to the ALS.  The logs will be
+   flushed to the ALS every time this duration is reached, or when the
+   buffered data reaches `flush_interval_byte_size`, whichever comes
+   first.  See the [Envoy documentation][flush_interval_time] for more
+   information.
+ - `flush_interval_byte_size` is soft size limit for the access log
+   buffer.  The logs will be flushed to the ALS every time the
+   buffered data reaches this size, or whenever `flush_interval_time`
+   elapses, whichever comes first.  See the [Envoy
+   documentation][flush_interval_byte_size] for more information.
+ - `grpc` must be `true`.
+
+[flush_interval_time]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/accesslog/v2/als.proto#envoy-api-field-config-accesslog-v2-commongrpcaccesslogconfig-flush-interval-time
+[flush_interval_byte_size]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/accesslog/v2/als.proto#envoy-api-field-config-accesslog-v2-commongrpcaccesslogconfig-flush-interval-byte-size
+
+## Example
+
+```yaml
+---
+apiVersion: getambassador.io/v2
+kind: LogService
+metadata:
+  name: als
+spec:
+  service: "als.default:3000"
+  driver: http
+  driver_config: {}  # NB: driver_config must be set, even if it's empty
+  grpc: true         # NB: grpc must be true
 ```

--- a/reference/services/log-service.md
+++ b/reference/services/log-service.md
@@ -21,10 +21,12 @@ kind: LogService
 metadata:
   name: example-log-service
 spec:
+  # Common to all Ambassador resources
   ambassador_id:           # optional; default is ["default"]
   - "string"
   ambassador_id: "string"  # no need for a list if there's only one value
 
+  # LogService specific
   service: "string"                 # required
   driver: "enum-string:[tcp, http]" # required
   driver_config:                    # required
@@ -39,26 +41,34 @@ spec:
 ```
 
  - `service` is where to route the access log gRPC requests to
+
  - `driver` identifies which type of accesses to log; HTTP requests (`"http"`) or
    TLS connections (`"tcp"`).
+
  - `driver_config` stores the configuration that is specific to the `driver`:
+
     * `driver: tcp` has no additional configuration; the config must
       be set as `driver_config: {}`.
+
     * `driver: http`
-	  - `additional_log_headers` identifies HTTP headers to include in
-        the access log, and when in the logged-request's lifecycle to
-        include them.
+
+       - `additional_log_headers` identifies HTTP headers to include in
+         the access log, and when in the logged-request's lifecycle to
+         include them.
+
  - `flush_interval_time` is the maximum number of seconds to buffer
    accesses for before sending them to the ALS.  The logs will be
    flushed to the ALS every time this duration is reached, or when the
    buffered data reaches `flush_interval_byte_size`, whichever comes
    first.  See the [Envoy documentation][flush_interval_time] for more
    information.
+
  - `flush_interval_byte_size` is soft size limit for the access log
    buffer.  The logs will be flushed to the ALS every time the
    buffered data reaches this size, or whenever `flush_interval_time`
    elapses, whichever comes first.  See the [Envoy
    documentation][flush_interval_byte_size] for more information.
+
  - `grpc` must be `true`.
 
 [flush_interval_time]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/accesslog/v2/als.proto#envoy-api-field-config-accesslog-v2-commongrpcaccesslogconfig-flush-interval-time

--- a/reference/services/log-service.md
+++ b/reference/services/log-service.md
@@ -60,19 +60,20 @@ spec:
    accesses for before sending them to the ALS.  The logs will be
    flushed to the ALS every time this duration is reached, or when the
    buffered data reaches `flush_interval_byte_size`, whichever comes
-   first.  See the [Envoy documentation][flush_interval_time] for more
+   first.  See the [Envoy documentation on
+   `buffer_flush_interval`][buffer_flush_interval] for more
    information.
 
  - `flush_interval_byte_size` is soft size limit for the access log
    buffer.  The logs will be flushed to the ALS every time the
    buffered data reaches this size, or whenever `flush_interval_time`
-   elapses, whichever comes first.  See the [Envoy
-   documentation][flush_interval_byte_size] for more information.
+   elapses, whichever comes first.  See the [Envoy documentation on
+   `buffer_size_bytes`][buffer_size_bytes] for more information.
 
  - `grpc` must be `true`.
 
-[flush_interval_time]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/accesslog/v2/als.proto#envoy-api-field-config-accesslog-v2-commongrpcaccesslogconfig-flush-interval-time
-[flush_interval_byte_size]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/accesslog/v2/als.proto#envoy-api-field-config-accesslog-v2-commongrpcaccesslogconfig-flush-interval-byte-size
+[buffer_flush_interval]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/accesslog/v2/als.proto#envoy-api-field-config-accesslog-v2-commongrpcaccesslogconfig-buffer-flush-interval
+[buffer_size_bytes]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/accesslog/v2/als.proto#envoy-api-field-config-accesslog-v2-commongrpcaccesslogconfig-buffer-size-bytes
 
 ## Example
 

--- a/reference/services/rate-limit-service.md
+++ b/reference/services/rate-limit-service.md
@@ -46,7 +46,9 @@ spec:
 
 ## External Rate Limit Service
 
-In order for Ambassador Edge Stack to rate limit, you need to implement a gRPC service that supports the Envoy [ratelimit.proto](https://github.com/datawire/ambassador/tree/master/docker/test-ratelimit/ratelimit.proto) interface. If you do not have the time or resources to implement your own rate limit service, Ambassador Edge Stack integrates a high performance, rate limiting service.
+In order for Ambassador Edge Stack to rate limit, you need to implement a gRPC `AccessLogService`, as defined in [Envoy's `rls.proto`][rls.proto] interface. If you do not have the time or resources to implement your own rate limit service, Ambassador Edge Stack integrates a high performance, rate limiting service.
+
+[rls.proto]: https://github.com/datawire/ambassador/tree/master/api/envoy/service/ratelimit/v2/rls.proto
 
 Ambassador Edge Stack generates a gRPC request to the external rate limit service and provides a list of labels on which the rate limit service can base its decision to accept or reject the request:
 

--- a/reference/services/services.md
+++ b/reference/services/services.md
@@ -2,9 +2,11 @@
 
 You may need an API Gateway to enforce policies specific to your organization. Ambassador Edge Stack supports custom policies through external service plugins. The policy logic specific to your organization is implemented in the external service, and Ambassador is configured to send RPC requests to your service.
 
-Currently, Ambassador Edge Stack supports plugins for authentication, rate limiting and tracing.
+Currently, Ambassador Edge Stack supports plugins for authentication,
+access logging, rate limiting and tracing.
 
 * [AuthService](../auth-service) Plugin
+* [LogService](../log-service) Plugin
 * [RateLimitService](../rate-limit-service) Plugin
 * [TracingService](../tracing-service) Plugin
 * [FilterPolicy](../access-control)


### PR DESCRIPTION
This documents the LogService, as it exists in Ambassador 0.86.1 and 1.0.0.

I hope @scoyle391 isn't too appalled at my writing style.  I hope that @nbkrause finds it clear enough that he can help our users who wish to use a LogService.