### PR TITLE
Remove the authservice plugin page

### DIFF
--- a/aes-pages.yml
+++ b/aes-pages.yml
@@ -51,7 +51,6 @@
 - /reference/rewrites
 - /reference/running
 - /reference/services/access-control
-- /reference/services/auth-service
 - /reference/services/log-service
 - /reference/services/rate-limit-service
 - /reference/services/services


### PR DESCRIPTION
This page is exclusive to OSS, not to AES. 