### PR TITLE
added links to the CRDs referenced in the table

### DIFF
--- a/reference/core/crds.md
+++ b/reference/core/crds.md
@@ -43,21 +43,21 @@ The full set of CRDs supported by the Ambassador Edge Stack are the following:
 
 | `Kind` | Kubernetes singular | Kubernetes plural |
 | :----- | :------------------ | :---------------- |
-| `AuthService` | `authservice` | `authservices` |
-| `ConsulResolver` | `consulresolver` | `consulresolvers` |
-| `Filter` | `filter` | `filters` |
-| `FilterPolicy` | `filterpolicy` | `filterpolicies`|
-| `Host` | `host`| `hosts` |
-| `KubernetesEndpointResolver` | `kubernetesendpointresolver` | `kubernetesendpointresolvers` |
-| `KubernetesServiceResolver` | `kubernetesserviceresolver` | `kubernetesserviceresolvers` |
-| `LogService` | `logservice` | `logservices` |
-| `Mapping` | `mapping` | `mappings` |
-| `Module` | `module` | `modules` |
-| `RateLimit` | `ratelimit` | `ratelimits` |
-| `RateLimitService` | `ratelimitservice` | `ratelimitservices` |
-| `TCPMapping` | `tcpmapping` | `tcpmappings` |
-| `TLSContext` | `tlscontext` | `tlscontexts` |
-| `TracingService` | `tracingservice` | `tracingservices` |
+| [`AuthService`](/reference/services/auth-service) | `authservice` | `authservices` |
+| [`ConsulResolver`](/reference/core/resolvers/#the-consul-resolver) | `consulresolver` | `consulresolvers` |
+| [`Filter`](/reference/filter-reference/) | `filter` | `filters` |
+| [`FilterPolicy`](/reference/services/access-control) | `filterpolicy` | `filterpolicies`|
+| [`Host`](/reference/host-crd/) | `host`| `hosts` |
+| [`KubernetesEndpointResolver`](/reference/core/resolvers/#the-kubernetes-endpoint-resolver) | `kubernetesendpointresolver` | `kubernetesendpointresolvers` |
+| [`KubernetesServiceResolver`](/reference/core/resolvers/#the-kubernetes-service-resolver) | `kubernetesserviceresolver` | `kubernetesserviceresolvers` |
+| [`LogService`](/reference/services/log-service) | `logservice` | `logservices` |
+| [`Mapping`](/reference/mappings/) | `mapping` | `mappings` |
+| [`Module`](/reference/modules/#module-configuration) | `module` | `modules` |
+| [`RateLimit`](/user-guide/advanced-rate-limiting/) | `ratelimit` | `ratelimits` |
+| [`RateLimitService`](/reference/services/rate-limit-service) | `ratelimitservice` | `ratelimitservices` |
+| [`TCPMapping`](/reference/tcpmappings/#tcpmapping) | `tcpmapping` | `tcpmappings` |
+| [`TLSContext`](/reference/core/tls/#tlscontext) | `tlscontext` | `tlscontexts` |
+| [`TracingService`](/reference/services/tracing-service) | `tracingservice` | `tracingservices` |
 
 So, for example, if you're using CRDs, then `kubectl get mappings` should show all your `Mapping` custom resources.
 

--- a/reference/core/crds.md
+++ b/reference/core/crds.md
@@ -48,6 +48,7 @@ The full set of CRDs supported by the Ambassador Edge Stack are the following:
 | [`Filter`](/reference/filter-reference/) | `filter` | `filters` |
 | [`FilterPolicy`](/reference/services/access-control) | `filterpolicy` | `filterpolicies`|
 | [`Host`](/reference/host-crd/) | `host`| `hosts` |
+| [`Ingress`](/reference/core/ingress-controller/) | `ingress` | `ingresses` |
 | [`KubernetesEndpointResolver`](/reference/core/resolvers/#the-kubernetes-endpoint-resolver) | `kubernetesendpointresolver` | `kubernetesendpointresolvers` |
 | [`KubernetesServiceResolver`](/reference/core/resolvers/#the-kubernetes-service-resolver) | `kubernetesserviceresolver` | `kubernetesserviceresolvers` |
 | [`LogService`](/reference/services/log-service) | `logservice` | `logservices` |


### PR DESCRIPTION
Noted in the OSS slack, this PR addressed the fact that the CRDs page has a table that lists all the  CRDs, but does not link directly to them.