### PR TITLE
Should not hardcode ns in example backend

### DIFF
--- a/yaml/backends/quote.yaml
+++ b/yaml/backends/quote.yaml
@@ -3,16 +3,14 @@ apiVersion: getambassador.io/v1
 kind: Mapping
 metadata:
   name: quote-backend
-  namespace: ambassador
 spec:
   prefix: /backend/
-  service: quote.ambassador
+  service: quote
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: quote
-  namespace: ambassador
 spec:
   ports:
   - name: http
@@ -25,7 +23,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: quote
-  namespace: ambassador
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
It was stupid to do this in the first place. Ambassador is now smart enough to not have to worry about the namespace when configuring a `Mapping` in the same namespace as the `Service` it is trying to reach.

Signed-off-by: Noah Krause <krausenoah@gmail.com>