### PR TITLE
Fix version ordering in ambassador-crds.yaml

### DIFF
--- a/yaml/ambassador/ambassador-crds.yaml
+++ b/yaml/ambassador/ambassador-crds.yaml
@@ -13,12 +13,12 @@ spec:
   scope: Namespaced
   version: v2
   versions:
-  - name: v1
-    served: true
-    storage: false
   - name: v2
     served: true
     storage: true
+  - name: v1
+    served: true
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -35,12 +35,12 @@ spec:
   scope: Namespaced
   version: v2
   versions:
-  - name: v1
-    served: true
-    storage: false
   - name: v2
     served: true
     storage: true
+  - name: v1
+    served: true
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -94,12 +94,12 @@ spec:
   scope: Namespaced
   version: v2
   versions:
-  - name: v1
-    served: true
-    storage: false
   - name: v2
     served: true
     storage: true
+  - name: v1
+    served: true
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -116,12 +116,12 @@ spec:
   scope: Namespaced
   version: v2
   versions:
-  - name: v1
-    served: true
-    storage: false
   - name: v2
     served: true
     storage: true
+  - name: v1
+    served: true
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -138,12 +138,12 @@ spec:
   scope: Namespaced
   version: v2
   versions:
-  - name: v1
-    served: true
-    storage: false
   - name: v2
     served: true
     storage: true
+  - name: v1
+    served: true
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -175,12 +175,12 @@ spec:
     status: {}
   version: v2
   versions:
-  - name: v1
-    served: true
-    storage: false
   - name: v2
     served: true
     storage: true
+  - name: v1
+    served: true
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -197,12 +197,12 @@ spec:
   scope: Namespaced
   version: v2
   versions:
-  - name: v1
-    served: true
-    storage: false
   - name: v2
     served: true
     storage: true
+  - name: v1
+    served: true
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -219,12 +219,12 @@ spec:
   scope: Namespaced
   version: v2
   versions:
-  - name: v1
-    served: true
-    storage: false
   - name: v2
     served: true
     storage: true
+  - name: v1
+    served: true
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -241,12 +241,12 @@ spec:
   scope: Namespaced
   version: v2
   versions:
-  - name: v1
-    served: true
-    storage: false
   - name: v2
     served: true
     storage: true
+  - name: v1
+    served: true
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -263,12 +263,12 @@ spec:
   scope: Namespaced
   version: v2
   versions:
-  - name: v1
-    served: true
-    storage: false
   - name: v2
     served: true
     storage: true
+  - name: v1
+    served: true
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -285,9 +285,9 @@ spec:
   scope: Namespaced
   version: v2
   versions:
-  - name: v1
-    served: true
-    storage: false
   - name: v2
     served: true
     storage: true
+  - name: v1
+    served: true
+    storage: false


### PR DESCRIPTION
This will happen with 1.2.0, but let's get it out more quickly if we can?