### PR TITLE
The Helm docs don't explain edgectl

### DIFF
--- a/user-guide/helm.md
+++ b/user-guide/helm.md
@@ -56,9 +56,7 @@ deploy it with either version of the tool.
    Congratulations, you’ve successfully installed the Ambassador Edge Stack in your Kubernetes cluster. Visit https://random-word.edgestack.me to access your Edge Stack installation and for additional configuration.
 ```
 
-[Edge Control](/reference/edge-control) (`edgectl`) automatically configures TLS for your instance and provisions a domain name for your Ambassador Edge Stack.
-
-This will install the necessary deployments, RBAC, Custom Resource Definitions, etc. for the Ambassador Edge Stack to route traffic. Details on how to configure Ambassador using the Helm chart can be found in the Helm chart [README](https://github.com/datawire/ambassador-chart/tree/master).
+Details on how to configure the Helm chart can be found in the [README](https://github.com/datawire/ambassador-chart/tree/master).
 
 ## Upgrading an Existing Ambassador Edge Stack Installation
 

--- a/user-guide/helm.md
+++ b/user-guide/helm.md
@@ -41,12 +41,12 @@ deploy it with either version of the tool.
    helm install --name ambassador --namespace ambassador datawire/ambassador
    ```
 
-4. Finish the installation by running the following command: `edgectl install`
-5. Provide an email address when prompted to receive notices if your domain or TLS certificate is about to expire.
+4. Download the `edgectl` command line tool ([Mac](https://metriton.datawire.io/downloads/darwin/edgectl) | [Linux] (https://metriton.datawire.io/downloads/linux/edgectl) | [Windows](https://metriton.datawire.io/downloads/windows/edgectl.exe)).
 
-Your terminal should print something similar to the following:
+5. Finish the installation by typing `./edgectl install` (on Mac/Linux) or `edgectl.exe install` (Windows). This will automatically provision a domain from edgestack.me you can use to access the Ambassador Edge Stack UI and obtain a TLS certificate from Let's Encrypt:
+
 ```
-   $ edgectl install
+   $ ./edgectl install
    -> Installing the Ambassador Edge Stack 1.0.
    -> Existing Ambassador Edge Stack installation detected.
    -> Automatically configuring TLS.


### PR DESCRIPTION
This fixes the Helm docs to point to edgectl download and corrects some other technical errors.