### PR TITLE
Adding warnings where host is used for requestpolicy overriding behavior

### DIFF
--- a/docs/1.11/howtos/grpc.md
+++ b/docs/1.11/howtos/grpc.md
@@ -155,6 +155,20 @@ spec:
 
 The Host is declared here because we are using gRPC without TLS.  Since Ambassador terminates TLS by default, in the Host we add a `requestPolicy` which allows insecure connections. After adding the Ambassador Edge Stack mapping to the service, the rest of the Kubernetes deployment YAML file is pretty straightforward. We need to identify the container image to use, expose the `containerPort` to listen on the same port the Docker container is listening on, and map the service port (80) to the container port (50051).
 
+> **WARNING - Host Configuration:** The `requestPolicy` property of the `Host` `CRD` is applied globally within an Edge Stack instance, even if it is applied to only one `Host` when multiple `Host`s are configured. Different `requestPolicy` behaviors cannot be applied to different `Host`s. It is recommended to apply an identical `requestPolicy` to all `Host`s instead of assuming the behavior, to create a more human readable config. 
+> 
+> If a requestPolicy is not defined for a `Host`, it's assumed to be `Redirect`, so even if a `Host` does not specify it, the default `requestPolicy` of `Redirect` will be applied to all `Host`s in that Edge Stack instance. If the behavior expected out of Edge Stack is anything other than `Redirect`, it must be explicitly enumerated in all Host resources. 
+> 
+> Unexpected behavior can occur when multiple `Host` resources are not using the same value for `requestPolicy`. 
+> The `insecure-action` can be one of:
+>
+> * `Redirect` (the default): redirect to HTTPS
+> * `Route`: go ahead and route as normal; this will allow handling HTTP requests normally
+> * `Reject`: reject the request with a 400 response
+>
+> For more information, please refer to the [`Host` documentation](../topics/running/host-crd#secure-and-insecure-requests).
+
+
 Once you have the YAML file and the correct Docker registry, deploy it to your cluster with `kubectl`.
 
 ```

--- a/docs/1.11/topics/running/tls/cleartext-redirection.md
+++ b/docs/1.11/topics/running/tls/cleartext-redirection.md
@@ -38,6 +38,21 @@ spec:
       action: Route
 ```
 
+> **WARNING - Host Configuration:** The `requestPolicy` property of the `Host` `CRD` is applied globally within an Edge Stack instance, even if it is applied to only one `Host` when multiple `Host`s are configured. Different `requestPolicy` behaviors cannot be applied to different `Host`s. It is recommended to apply an identical `requestPolicy` to all `Host`s instead of assuming the behavior, to create a more human readable config. 
+> 
+> If a requestPolicy is not defined for a `Host`, it's assumed to be `Redirect`, so even if a `Host` does not specify it, the default `requestPolicy` of `Redirect` will be applied to all `Host`s in that Edge Stack instance. If the behavior expected out of Edge Stack is anything other than `Redirect`, it must be explicitly enumerated in all Host resources. 
+> 
+> Unexpected behavior can occur when multiple `Host` resources are not using the same value for `requestPolicy`. 
+> 
+> For more information, please refer to the [`Host` documentation](../host-crd#secure-and-insecure-requests).
+>
+>The `insecure-action` can be one of:
+>
+>* `Redirect` (the default): redirect to HTTPS
+>* `Route`: go ahead and route as normal; this will allow handling HTTP requests normally
+>* `Reject`: reject the request with a 400 response
+
+
 ### HTTPS and Cleartext
 
 Ambassador can also support serving both HTTPS and cleartext traffic from a
@@ -67,6 +82,15 @@ spec:
 With the above configuration, we are tell Ambassador to terminate TLS with the
 certificate in the `example-cert` `Secret` and route cleartext traffic that
 comes in over port `8080`.
+
+> The `additionalPort` element tells Ambassador to listen on the specified `insecure-port` and treat any request arriving on that port as insecure. **By default, `additionalPort` will be set to 8080 for any `Host` using TLS.** To disable this redirection entirely, set `additionalPort` explicitly to `-1`:
+```yaml
+requestPolicy:
+  insecure:
+    additionalPort: -1   # This is how to disable the default redirection from 8080.
+```
+
+
 
 ## HTTP->HTTPS Redirection
 

--- a/docs/1.11/topics/running/tls/index.md
+++ b/docs/1.11/topics/running/tls/index.md
@@ -16,6 +16,23 @@ in Ambassador and defines how TLS is managed on that domain. In the Ambassador
 Edge Stack, the simplest configuration of a `Host` will enable TLS with a 
 self-signed certificate and redirect cleartext traffic to HTTPS. 
 
+> **WARNING - Host Configuration:** The `requestPolicy` property of the `Host` `CRD` is applied globally within an Edge Stack instance, even if it is applied to only one `Host` when multiple `Host`s are configured. Different `requestPolicy` behaviors cannot be applied to different `Host`s. It is recommended to apply an identical `requestPolicy` to all `Host`s instead of assuming the behavior, to create a more human readable config. 
+> 
+> If a requestPolicy is not defined for a `Host`, it's assumed to be `Redirect`, so even if a `Host` does not specify it, the default `requestPolicy` of `Redirect` will be applied to all `Host`s in that Edge Stack instance. If the behavior expected out of Edge Stack is anything other than `Redirect`, it must be explicitly enumerated in all Host resources. 
+> 
+> Unexpected behavior can occur when multiple `Host` resources are not using the same value for `requestPolicy`. 
+> 
+> The `insecure-action` can be one of:
+>
+> * `Redirect` (the default): redirect to HTTPS
+> * `Route`: go ahead and route as normal; this will allow handling HTTP requests normally
+> * `Reject`: reject the request with a 400 response
+>
+> The example below does not define a `requestPolicy`; however, this is something to keep in mind as you begin using the `Host` `CRD` in Ambassador.
+>
+> For more information, please refer to the [`Host` documentation](../host-crd#secure-and-insecure-requests).
+
+
 ### Automatic TLS with ACME
 
 With the Ambassador Edge Stack, the `Host` can be configured to completely 
@@ -74,9 +91,19 @@ The `Host` will configure basic TLS termination settings in Ambassador. If you
 need more advanced TLS options on a domain, such as setting the minimum TLS 
 version, you can do it in one of the following ways.
 
-1. [Create a `TLSContext` with the name `{{HOST}}-context`](#create-a-tlscontext-with-the-name-host-context)
-2. [Link a `TLSContext` to the Host](#link-a-tlscontext-to-the-host)
-3. [Specify TLS configuration in the Host](#specify-tls-configuration-in-the-host)
+- [Transport Layer Security (TLS)](#transport-layer-security-tls)
+  - [`Host`](#host)
+    - [Automatic TLS with ACME](#automatic-tls-with-acme)
+    - [Bring your own certificate](#bring-your-own-certificate)
+    - [`Host` and `TLSContext`](#host-and-tlscontext)
+      - [Create a `TLSContext` with the name `{{HOST}}-context`](#create-a-tlscontext-with-the-name-host-context)
+      - [Link a `TLSContext` to the Host](#link-a-tlscontext-to-the-host)
+      - [Specify TLS configuration in the Host](#specify-tls-configuration-in-the-host)
+  - [TLSContext](#tlscontext)
+    - [`alpn_protocols`](#alpn_protocols)
+      - [HTTP/2 Support](#http2-support)
+    - [TLS Parameters](#tls-parameters)
+  - [TLS `Module` (*Deprecated*)](#tls-module-deprecated)
 
 #### Create a `TLSContext` with the name `{{HOST}}-context`
 

--- a/docs/pre-release/howtos/grpc.md
+++ b/docs/pre-release/howtos/grpc.md
@@ -155,6 +155,20 @@ spec:
 
 The Host is declared here because we are using gRPC without TLS.  Since Ambassador terminates TLS by default, in the Host we add a `requestPolicy` which allows insecure connections. After adding the Ambassador Edge Stack mapping to the service, the rest of the Kubernetes deployment YAML file is pretty straightforward. We need to identify the container image to use, expose the `containerPort` to listen on the same port the Docker container is listening on, and map the service port (80) to the container port (50051).
 
+> **WARNING - Host Configuration:** The `requestPolicy` property of the `Host` `CRD` is applied globally within an Edge Stack instance, even if it is applied to only one `Host` when multiple `Host`s are configured. Different `requestPolicy` behaviors cannot be applied to different `Host`s. It is recommended to apply an identical `requestPolicy` to all `Host`s instead of assuming the behavior, to create a more human readable config. 
+> 
+> If a requestPolicy is not defined for a `Host`, it's assumed to be `Redirect`, so even if a `Host` does not specify it, the default `requestPolicy` of `Redirect` will be applied to all `Host`s in that Edge Stack instance. If the behavior expected out of Edge Stack is anything other than `Redirect`, it must be explicitly enumerated in all Host resources. 
+> 
+> Unexpected behavior can occur when multiple `Host` resources are not using the same value for `requestPolicy`. 
+> The `insecure-action` can be one of:
+>
+> * `Redirect` (the default): redirect to HTTPS
+> * `Route`: go ahead and route as normal; this will allow handling HTTP requests normally
+> * `Reject`: reject the request with a 400 response
+>
+> For more information, please refer to the [`Host` documentation](../topics/running/host-crd#secure-and-insecure-requests).
+
+
 Once you have the YAML file and the correct Docker registry, deploy it to your cluster with `kubectl`.
 
 ```

--- a/docs/pre-release/topics/running/tls/cleartext-redirection.md
+++ b/docs/pre-release/topics/running/tls/cleartext-redirection.md
@@ -38,6 +38,22 @@ spec:
       action: Route
 ```
 
+> **WARNING - Host Configuration:** The `requestPolicy` property of the `Host` `CRD` is applied globally within an Edge Stack instance, even if it is applied to only one `Host` when multiple `Host`s are configured. Different `requestPolicy` behaviors cannot be applied to different `Host`s. It is recommended to apply an identical `requestPolicy` to all `Host`s instead of assuming the behavior, to create a more human readable config. 
+> 
+> If a requestPolicy is not defined for a `Host`, it's assumed to be `Redirect`, so even if a `Host` does not specify it, the default `requestPolicy` of `Redirect` will be applied to all `Host`s in that Edge Stack instance. If the behavior expected out of Edge Stack is anything other than `Redirect`, it must be explicitly enumerated in all Host resources. 
+> 
+> Unexpected behavior can occur when multiple `Host` resources are not using the same value for `requestPolicy`. 
+> 
+> For more information, please refer to the [`Host` documentation](../host-crd#secure-and-insecure-requests).
+> 
+> The `insecure-action` can be one of:
+>
+>* `Redirect` (the default): redirect to HTTPS
+>* `Route`: go ahead and route as normal; this will allow handling HTTP requests normally
+>* `Reject`: reject the request with a 400 response
+
+
+
 ### HTTPS and Cleartext
 
 Ambassador can also support serving both HTTPS and cleartext traffic from a
@@ -67,6 +83,13 @@ spec:
 With the above configuration, we are tell Ambassador to terminate TLS with the
 certificate in the `example-cert` `Secret` and route cleartext traffic that
 comes in over port `8080`.
+
+> The `additionalPort` element tells Ambassador to listen on the specified `insecure-port` and treat any request arriving on that port as insecure. **By default, `additionalPort` will be set to 8080 for any `Host` using TLS.** To disable this redirection entirely, set `additionalPort` explicitly to `-1`:
+```yaml
+requestPolicy:
+  insecure:
+    additionalPort: -1   # This is how to disable the default redirection from 8080.
+```
 
 ## HTTP->HTTPS Redirection
 

--- a/docs/pre-release/topics/running/tls/index.md
+++ b/docs/pre-release/topics/running/tls/index.md
@@ -16,6 +16,23 @@ in Ambassador and defines how TLS is managed on that domain. In the Ambassador
 Edge Stack, the simplest configuration of a `Host` will enable TLS with a 
 self-signed certificate and redirect cleartext traffic to HTTPS. 
 
+> **WARNING - Host Configuration:** The `requestPolicy` property of the `Host` `CRD` is applied globally within an Edge Stack instance, even if it is applied to only one `Host` when multiple `Host`s are configured. Different `requestPolicy` behaviors cannot be applied to different `Host`s. It is recommended to apply an identical `requestPolicy` to all `Host`s instead of assuming the behavior, to create a more human readable config. 
+> 
+> If a requestPolicy is not defined for a `Host`, it's assumed to be `Redirect`, so even if a `Host` does not specify it, the default `requestPolicy` of `Redirect` will be applied to all `Host`s in that Edge Stack instance. If the behavior expected out of Edge Stack is anything other than `Redirect`, it must be explicitly enumerated in all Host resources. 
+> 
+> Unexpected behavior can occur when multiple `Host` resources are not using the same value for `requestPolicy`. 
+> 
+> The `insecure-action` can be one of:
+>
+> * `Redirect` (the default): redirect to HTTPS
+> * `Route`: go ahead and route as normal; this will allow handling HTTP requests normally
+> * `Reject`: reject the request with a 400 response
+>
+> The example below does not define a `requestPolicy`; however, this is something to keep in mind as you begin using the `Host` `CRD` in Ambassador.
+>
+> For more information, please refer to the [`Host` documentation](../host-crd#secure-and-insecure-requests).
+
+
 ### Automatic TLS with ACME
 
 With the Ambassador Edge Stack, the `Host` can be configured to completely 
@@ -74,9 +91,19 @@ The `Host` will configure basic TLS termination settings in Ambassador. If you
 need more advanced TLS options on a domain, such as setting the minimum TLS 
 version, you can do it in one of the following ways.
 
-1. [Create a `TLSContext` with the name `{{HOST}}-context`](#create-a-tlscontext-with-the-name-host-context)
-2. [Link a `TLSContext` to the Host](#link-a-tlscontext-to-the-host)
-3. [Specify TLS configuration in the Host](#specify-tls-configuration-in-the-host)
+- [Transport Layer Security (TLS)](#transport-layer-security-tls)
+  - [`Host`](#host)
+    - [Automatic TLS with ACME](#automatic-tls-with-acme)
+    - [Bring your own certificate](#bring-your-own-certificate)
+    - [`Host` and `TLSContext`](#host-and-tlscontext)
+      - [Create a `TLSContext` with the name `{{HOST}}-context`](#create-a-tlscontext-with-the-name-host-context)
+      - [Link a `TLSContext` to the Host](#link-a-tlscontext-to-the-host)
+      - [Specify TLS configuration in the Host](#specify-tls-configuration-in-the-host)
+  - [TLSContext](#tlscontext)
+    - [`alpn_protocols`](#alpn_protocols)
+      - [HTTP/2 Support](#http2-support)
+    - [TLS Parameters](#tls-parameters)
+  - [TLS `Module` (*Deprecated*)](#tls-module-deprecated)
 
 #### Create a `TLSContext` with the name `{{HOST}}-context`
 


### PR DESCRIPTION
I added details to the warning about requestPolicy field of the Host CRD overriding the requestPolicy of all other hosts. This behavior occurs even when the value is not set by the user since it gets a default value. The host with the highest alphabetic metadata.name will have its requestPolicy override all other hosts in the cluster. 

We already have a warning for this, but I wanted to add more details to make it clear to the users what will happen if they do not keep this in mind when using Hosts. I also wanted to add this info to all the other pages where a Host is used since someone who is only following tutorials may not see the warning on the Host CRD page.

Please take a look at let me know if any changes are required.