### PR TITLE
Update the link to httpbin OpenAPI definition

### DIFF
--- a/docs/1.10/topics/using/dev-portal.md
+++ b/docs/1.10/topics/using/dev-portal.md
@@ -75,7 +75,7 @@ spec:
   prefix: /httpbin/
   service: httpbin.org
   docs:
-    url: https://api.swaggerhub.com/apis/helen/httpbin/1.0-oas3/swagger.json
+    url: https://httpbin.org/spec.json
 ```
 
 > Notes on access to documentation `path`s:

--- a/docs/1.11/topics/using/dev-portal.md
+++ b/docs/1.11/topics/using/dev-portal.md
@@ -84,7 +84,7 @@ spec:
   prefix: /httpbin/
   service: httpbin.org
   docs:
-    url: https://api.swaggerhub.com/apis/helen/httpbin/1.0-oas3/swagger.json
+    url: https://httpbin.org/spec.json
 ```
 
 > Notes on access to documentation `path`s:

--- a/docs/1.12/topics/using/dev-portal.md
+++ b/docs/1.12/topics/using/dev-portal.md
@@ -84,7 +84,7 @@ spec:
   prefix: /httpbin/
   service: httpbin.org
   docs:
-    url: https://api.swaggerhub.com/apis/helen/httpbin/1.0-oas3/swagger.json
+    url: https://httpbin.org/spec.json
 ```
 
 > Notes on access to documentation `path`s:

--- a/docs/1.9/topics/using/dev-portal.md
+++ b/docs/1.9/topics/using/dev-portal.md
@@ -75,7 +75,7 @@ spec:
   prefix: /httpbin/
   service: httpbin.org
   docs:
-    url: https://api.swaggerhub.com/apis/helen/httpbin/1.0-oas3/swagger.json
+    url: https://httpbin.org/spec.json
 ```
 
 > Notes on access to documentation `path`s:

--- a/docs/pre-release/topics/using/dev-portal.md
+++ b/docs/pre-release/topics/using/dev-portal.md
@@ -84,7 +84,7 @@ spec:
   prefix: /httpbin/
   service: httpbin.org
   docs:
-    url: https://api.swaggerhub.com/apis/helen/httpbin/1.0-oas3/swagger.json
+    url: https://httpbin.org/spec.json
 ```
 
 > Notes on access to documentation `path`s:


### PR DESCRIPTION
One of the examples on the "Developer Portal" help page includes a link to the OpenAPI spec for the httpbin.org service.
httpbin has an official OpenAPI spec at https://httpbin.org/spec.json.
This PR updates the example to use the official spec.

The unofficial spec on SwaggerHub is no longer available (it was mine, I deleted it).