### PR TITLE
docs/aws: lowercase rfc 1123 labels

### DIFF
--- a/docs/emissary/2.0/topics/running/ambassador-with-aws.md
+++ b/docs/emissary/2.0/topics/running/ambassador-with-aws.md
@@ -26,10 +26,10 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-  - name: HTTP
+  - name: http
     port: 80
     targetPort: 8080
-  - name: HTTPS
+  - name: https
     port: 443
     targetPort: 8443
   selector:


### PR DESCRIPTION
The spec failed validation:

> The Service "ambassador" is invalid: spec.ports[0].name: Invalid value: "HTTP": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9][a-z0-9])?')