### PR TITLE
Update curl example in traffic-management.md to use HTTP

### DIFF
--- a/docs/argo/latest/howtos/traffic-management.md
+++ b/docs/argo/latest/howtos/traffic-management.md
@@ -181,7 +181,7 @@ argocd app sync echo
 Verify that the canary is progressing appropriately by sending curl requests in a loop:
 
 ```
-while true; do curl -k https://$LOAD_BALANCER_IP/echo/ ; sleep 0.2; done
+while true; do curl -k http://$LOAD_BALANCER_IP/echo/ ; sleep 0.2; done
 ```
 
 This will display a running list of responses from the service that will gradually transition from `Canary v1` strings to `Canary v2` strings.


### PR DESCRIPTION
The service is configured with HTTP only in this example so the curl command attempting to connect via HTTPS will always fail.