### PR TITLE
Missing "limits" from example

### DIFF
--- a/docs/edge-stack/2.1/howtos/token-ratelimit.md
+++ b/docs/edge-stack/2.1/howtos/token-ratelimit.md
@@ -112,6 +112,7 @@ metadata:
   name: token-name-rate-limit
 spec:
   domain: ambassador
+  limits:
   - name: token-name-per-minute
     action: Enforce
     pattern:


### PR DESCRIPTION
Without "limits", the example doesn't work, even if I set only one limit.