### PR TITLE
Update Argo docs to reference edge-stack instead of ambassador app

### DIFF
--- a/docs/argo/latest/howtos/traffic-management.md
+++ b/docs/argo/latest/howtos/traffic-management.md
@@ -126,7 +126,7 @@ argocd app create --name echo --repo https://github.com/<your Github username>/a
 
 To access your deployed app, first get your load balancer IP:
 ```
-export LOAD_BALANCER_IP=$(kubectl -n ambassador get svc ambassador -o "go-template={{range .status.loadBalancer.ingress}}{{or .ip .hostname}}{{end}}")
+export LOAD_BALANCER_IP=$(kubectl -n ambassador get svc edge-stack -o "go-template={{range .status.loadBalancer.ingress}}{{or .ip .hostname}}{{end}}")
 ```
 
 Now curl the service:


### PR DESCRIPTION
While going through the quick start guide here https://www.getambassador.io/docs/argo/latest/howtos/traffic-management/ , I've found that there is no longer an `ambassador` app if you are using the `edge-stack`, so attempting to get the LB address from the `ambassador` svc won't work. Updating it to use `edge-stack` as the svc fixes it.