### PR TITLE
fix docker image repo name

### DIFF
--- a/docs/emissary/2.2/topics/install/docker.md
+++ b/docs/emissary/2.2/topics/install/docker.md
@@ -11,7 +11,7 @@ deploy $productName$ in Kubernetes with a custom configuration.
 By default, $productName$ uses a demo configuration to show some of its basic features. Get it running with Docker, and expose $productName$ on port 8080:
 
 ```
-docker run -it -p 8080:8080 --name=$productDeploymentName$ --rm docker.io/datawire/emissary:$version$ --demo
+docker run -it -p 8080:8080 --name=$productDeploymentName$ --rm emissaryingress/emissary:$version$ --demo
 ```
 
 ## 2. $productName$'s diagnostics


### PR DESCRIPTION
The Docker repo in this doc is wrong, or at least images have not been pushed to `datawire/emissary` in some time.