### PR TITLE
Update auth_context_extensions documentation

### DIFF
--- a/docs/emissary/1.13/topics/using/authservice.md
+++ b/docs/emissary/1.13/topics/using/authservice.md
@@ -10,9 +10,10 @@ An AuthService can be disabled for a specific Mapping with the `bypass_auth` att
 bypass_auth: true
 ```
 
-## Context extensions
+## Context extensions (gRPC only)
 
-The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens.  The values are arbitrary key value pairs formatted as strings.
+The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying envoy implementation.
+The values are arbitrary key value pairs formatted as strings.
 
 ```yaml
 auth_context_extensions:

--- a/docs/emissary/1.13/topics/using/authservice.md
+++ b/docs/emissary/1.13/topics/using/authservice.md
@@ -12,7 +12,7 @@ bypass_auth: true
 
 ## Context extensions (gRPC only)
 
-The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying envoy implementation.
+The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying Envoy implementation.
 The values are arbitrary key value pairs formatted as strings.
 
 ```yaml

--- a/docs/emissary/1.14/topics/using/authservice.md
+++ b/docs/emissary/1.14/topics/using/authservice.md
@@ -10,9 +10,10 @@ An AuthService can be disabled for a specific Mapping with the `bypass_auth` att
 bypass_auth: true
 ```
 
-## Context extensions
+## Context extensions (gRPC only)
 
-The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens.  The values are arbitrary key value pairs formatted as strings.
+The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying envoy implementation.
+The values are arbitrary key value pairs formatted as strings.
 
 ```yaml
 auth_context_extensions:

--- a/docs/emissary/1.14/topics/using/authservice.md
+++ b/docs/emissary/1.14/topics/using/authservice.md
@@ -12,7 +12,7 @@ bypass_auth: true
 
 ## Context extensions (gRPC only)
 
-The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying envoy implementation.
+The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying Envoy implementation.
 The values are arbitrary key value pairs formatted as strings.
 
 ```yaml

--- a/docs/emissary/2.0/topics/using/authservice.md
+++ b/docs/emissary/2.0/topics/using/authservice.md
@@ -10,9 +10,10 @@ An AuthService can be disabled for a specific Mapping with the `bypass_auth` att
 bypass_auth: true
 ```
 
-## Context extensions
+## Context extensions (gRPC only)
 
-The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens.  The values are arbitrary key value pairs formatted as strings.
+The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying envoy implementation.
+The values are arbitrary key value pairs formatted as strings.
 
 ```yaml
 auth_context_extensions:

--- a/docs/emissary/2.0/topics/using/authservice.md
+++ b/docs/emissary/2.0/topics/using/authservice.md
@@ -12,7 +12,7 @@ bypass_auth: true
 
 ## Context extensions (gRPC only)
 
-The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying envoy implementation.
+The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying Envoy implementation.
 The values are arbitrary key value pairs formatted as strings.
 
 ```yaml

--- a/docs/emissary/2.1/topics/using/authservice.md
+++ b/docs/emissary/2.1/topics/using/authservice.md
@@ -10,9 +10,10 @@ An AuthService can be disabled for a specific Mapping with the `bypass_auth` att
 bypass_auth: true
 ```
 
-## Context extensions
+## Context extensions (gRPC only)
 
-The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens.  The values are arbitrary key value pairs formatted as strings.
+The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying envoy implementation.
+The values are arbitrary key value pairs formatted as strings.
 
 ```yaml
 auth_context_extensions:

--- a/docs/emissary/2.1/topics/using/authservice.md
+++ b/docs/emissary/2.1/topics/using/authservice.md
@@ -12,7 +12,7 @@ bypass_auth: true
 
 ## Context extensions (gRPC only)
 
-The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying envoy implementation.
+The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying Envoy implementation.
 The values are arbitrary key value pairs formatted as strings.
 
 ```yaml

--- a/docs/emissary/2.2/topics/using/authservice.md
+++ b/docs/emissary/2.2/topics/using/authservice.md
@@ -10,9 +10,10 @@ An AuthService can be disabled for a specific Mapping with the `bypass_auth` att
 bypass_auth: true
 ```
 
-## Context extensions
+## Context extensions (gRPC only)
 
-The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens.  The values are arbitrary key value pairs formatted as strings.
+The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying envoy implementation.
+The values are arbitrary key value pairs formatted as strings.
 
 ```yaml
 auth_context_extensions:

--- a/docs/emissary/2.2/topics/using/authservice.md
+++ b/docs/emissary/2.2/topics/using/authservice.md
@@ -12,7 +12,7 @@ bypass_auth: true
 
 ## Context extensions (gRPC only)
 
-The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying envoy implementation.
+The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying Envoy implementation.
 The values are arbitrary key value pairs formatted as strings.
 
 ```yaml

--- a/docs/emissary/2.3/topics/using/authservice.md
+++ b/docs/emissary/2.3/topics/using/authservice.md
@@ -10,9 +10,10 @@ An AuthService can be disabled for a specific Mapping with the `bypass_auth` att
 bypass_auth: true
 ```
 
-## Context extensions
+## Context extensions (gRPC only)
 
-The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens.  The values are arbitrary key value pairs formatted as strings.
+The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying envoy implementation.
+The values are arbitrary key value pairs formatted as strings.
 
 ```yaml
 auth_context_extensions:

--- a/docs/emissary/2.3/topics/using/authservice.md
+++ b/docs/emissary/2.3/topics/using/authservice.md
@@ -12,7 +12,7 @@ bypass_auth: true
 
 ## Context extensions (gRPC only)
 
-The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying envoy implementation.
+The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying Envoy implementation.
 The values are arbitrary key value pairs formatted as strings.
 
 ```yaml

--- a/docs/emissary/3.0/topics/using/authservice.md
+++ b/docs/emissary/3.0/topics/using/authservice.md
@@ -10,9 +10,10 @@ An AuthService can be disabled for a specific Mapping with the `bypass_auth` att
 bypass_auth: true
 ```
 
-## Context extensions
+## Context extensions (gRPC only)
 
-The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens.  The values are arbitrary key value pairs formatted as strings.
+The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying envoy implementation.
+The values are arbitrary key value pairs formatted as strings.
 
 ```yaml
 auth_context_extensions:

--- a/docs/emissary/3.0/topics/using/authservice.md
+++ b/docs/emissary/3.0/topics/using/authservice.md
@@ -12,7 +12,7 @@ bypass_auth: true
 
 ## Context extensions (gRPC only)
 
-The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying envoy implementation.
+The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying Envoy implementation.
 The values are arbitrary key value pairs formatted as strings.
 
 ```yaml

--- a/docs/emissary/3.1/topics/using/authservice.md
+++ b/docs/emissary/3.1/topics/using/authservice.md
@@ -10,9 +10,10 @@ An AuthService can be disabled for a specific Mapping with the `bypass_auth` att
 bypass_auth: true
 ```
 
-## Context extensions
+## Context extensions (gRPC only)
 
-The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens.  The values are arbitrary key value pairs formatted as strings.
+The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying envoy implementation.
+The values are arbitrary key value pairs formatted as strings.
 
 ```yaml
 auth_context_extensions:

--- a/docs/emissary/3.1/topics/using/authservice.md
+++ b/docs/emissary/3.1/topics/using/authservice.md
@@ -12,7 +12,7 @@ bypass_auth: true
 
 ## Context extensions (gRPC only)
 
-The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying envoy implementation.
+The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying Envoy implementation.
 The values are arbitrary key value pairs formatted as strings.
 
 ```yaml

--- a/docs/emissary/pre-release/topics/using/authservice.md
+++ b/docs/emissary/pre-release/topics/using/authservice.md
@@ -10,9 +10,10 @@ An AuthService can be disabled for a specific Mapping with the `bypass_auth` att
 bypass_auth: true
 ```
 
-## Context extensions
+## Context extensions (gRPC only)
 
-The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens.  The values are arbitrary key value pairs formatted as strings.
+The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying envoy implementation.
+The values are arbitrary key value pairs formatted as strings.
 
 ```yaml
 auth_context_extensions:

--- a/docs/emissary/pre-release/topics/using/authservice.md
+++ b/docs/emissary/pre-release/topics/using/authservice.md
@@ -12,7 +12,7 @@ bypass_auth: true
 
 ## Context extensions (gRPC only)
 
-The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying envoy implementation.
+The `auth_context_extensions` attribute will pass the given values along to the AuthService when authentication happens. This is only supported when the `proto` of the AuthService is `grpc`, which is a restriction of the underlying Envoy implementation.
 The values are arbitrary key value pairs formatted as strings.
 
 ```yaml


### PR DESCRIPTION
As [discussed](https://datawire-oss.slack.com/archives/CAULN7S76/p1659718202762449) in the Ambassador Labs Community slack, this change clarifies that the `auth_context_extensions` values are only passed to a gRPC AuthService.