### PR TITLE
Fixing YAML indenting

### DIFF
--- a/docs/emissary/3.1/howtos/http3-gke.md
+++ b/docs/emissary/3.1/howtos/http3-gke.md
@@ -36,8 +36,8 @@ spec:
       port: 443
       targetPort: 8443
       protocol: TCP
-  ---
-  apiVersion: v1
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: $productDeploymentName$-udp


### PR DESCRIPTION
UPD Loadbalancer Service manifest had incorrect YAML indenting in GKE guide