### PR TITLE
feat: new env AMBASSADOR_WATCHER_FIELD_SELECTOR and AMBASSADOR_WATCHER_LABEL_SELECTOR

### DIFF
--- a/docs/emissary/pre-release/topics/running/environment.md
+++ b/docs/emissary/pre-release/topics/running/environment.md
@@ -167,12 +167,12 @@ Then set `AMBASSADOR_WATCHER_FIELD_SELECTOR=spec.myField` in the  $productName$ 
 Resources without the specified label will be ignored.
 
 You may also specify this on a per-resourcegroup basis. For example to specify a field selector to only fetch secrets of type tls you may use:
-`AMBASSADOR_WATCHER_FIELD_SELECTOR=secrets.v1:type=kubernetes.io/tls`
+`AMBASSADOR_WATCHER_FIELD_SELECTOR=secrets.v1.:type=kubernetes.io/tls`
 
 You may specify multiple fields delimited by `,` and multiple group selectors delimited by `;`
 
 Example: 
-`AMBASSADOR_WATCHER_FIELD_SELECTOR=secrets.v1:type=kubernetes.io/tls;mappings.v3alpha1:metadata.name=dummy`
+`AMBASSADOR_WATCHER_FIELD_SELECTOR=secrets.v1.:type=kubernetes.io/tls;mappings.v3alpha1:metadata.name=dummy`
 
 ### `AMBASSADOR_WATCHER_LABEL_SELECTOR`
 
@@ -186,7 +186,7 @@ You may also specify this on a per-resourcegroup basis. For example to specify a
 You may specify multiple fields delimited by `,` and multiple group selectors delimited by `;`
 
 Example: 
-`AMBASSADOR_WATCHER_LABEL_SELECTOR=secrets.v1:ambassador-secret=true,ambassador-version=v3;mappings.v3alpha1:ambassador-version=v3`
+`AMBASSADOR_WATCHER_LABEL_SELECTOR=secrets.v1.:ambassador-secret=true,ambassador-version=v3;mappings.v3alpha1:ambassador-version=v3`
 
 ### `AMBASSADOR_NAMESPACE`
 

--- a/docs/emissary/pre-release/topics/running/environment.md
+++ b/docs/emissary/pre-release/topics/running/environment.md
@@ -17,7 +17,10 @@ Use the following variables for the environment of your $productName$ container:
 | [`AMBASSADOR_GRPC_METRICS_SINK`](#ambassador_grpc_metrics_sink)                                            | Empty                                               | String (address:port) |
 | [`AMBASSADOR_ISTIO_SECRET_DIR`](#ambassador_istio_secret_dir)                                              | `/etc/istio-certs`                                  | String |
 | [`AMBASSADOR_JSON_LOGGING`](#ambassador_json_logging)                                                      | `false`                                             | Boolean; non-empty=true, empty=false |
+| [`AMBASSADOR_FIELD_SELECTOR`](#ambassador_field selector)                                                  | Empty                                               | String (label=value) |
 | [`AMBASSADOR_LABEL_SELECTOR`](#ambassador_label_selector)                                                  | Empty                                               | String (label=value) |
+| [`AMBASSADOR_WATCHER_FIELD_SELECTOR`](#ambassador_watcher_field_selector)                                  | Empty                                               | String ([resourcegroup.v1:]spec.field=value[;]) |
+| [`AMBASSADOR_WATCHER_LABEL_SELECTOR`](#ambassador_watcher_label_selector)                                  | Empty                                               | String ([resourcegroup.v1:]label1=value1,label2=value2[;]) |
 | [`AMBASSADOR_NAMESPACE`](#ambassador_namespace)                                                            | `default` ([^1])                                    | Kubernetes namespace |
 | [`AMBASSADOR_RECONFIG_MAX_DELAY`](#ambassador_reconfig_max_delay)                                          | `1`                                                 | Integer |
 | [`AMBASSADOR_SINGLE_NAMESPACE`](#ambassador_single_namespace)                                              | Empty                                               | Boolean; non-empty=true, empty=false |
@@ -141,11 +144,49 @@ Some (but few) logs from `gunicorn` and the Kubernetes `client-go` package will 
 
 [More information](../../running/running#log-format)
 
+### `AMBASSADOR_FIELD_SELECTOR`
+
+**DEPRECATED**: See [AMBASSADOR_WATCHER_FIELD_SELECTOR](#ambassador_watcher_field_selector)
+
+Restricts $productName$'s configuration to only the matching fields. For example, you could have a field `spec.myField` present accross all resources.
+Then set `AMBASSADOR_FIELD_SELECTOR=spec.myField` in the  $productName$ Deployment.
+Resources without the specified label will be ignored.
+
 ### `AMBASSADOR_LABEL_SELECTOR`
+
+**DEPRECATED**: See [AMBASSADOR_WATCHER_LABEL_SELECTOR](#ambassador_watcher_label_selector)
 
 Restricts $productName$'s configuration to only the labelled resources. For example, you could apply a `version-two: true` label
 to all resources that should be visible to $productName$, then set `AMBASSADOR_LABEL_SELECTOR=version-two=true` in its Deployment.
 Resources without the specified label will be ignored.
+
+### `AMBASSADOR_WATCHER_FIELD_SELECTOR`
+
+Restricts $productName$'s configuration to only the matching fields. For example, you could have a field `spec.myField` present accross resources.
+Then set `AMBASSADOR_WATCHER_FIELD_SELECTOR=spec.myField` in the  $productName$ Deployment.
+Resources without the specified label will be ignored.
+
+You may also specify this on a per-resourcegroup basis. For example to specify a field selector to only fetch secrets of type tls you may use:
+`AMBASSADOR_WATCHER_FIELD_SELECTOR=secrets.v1:type=kubernetes.io/tls`
+
+You may specify multiple fields delimited by `,` and multiple group selectors delimited by `;`
+
+Example: 
+`AMBASSADOR_WATCHER_FIELD_SELECTOR=secrets.v1:type=kubernetes.io/tls;mappings.v3alpha1:metadata.name=dummy`
+
+### `AMBASSADOR_WATCHER_LABEL_SELECTOR`
+
+Restricts $productName$'s configuration to only the labelled resources. For example, you could apply a `version-two: true` label
+to all resources that should be visible to $productName$, then set `AMBASSADOR_WATCHER_LABEL_SELECTOR=version-two=true` in its Deployment.
+Resources without the specified label will be ignored.
+
+You may also specify this on a per-resourcegroup basis. For example to specify a label selector to only fetch mappings with the label `version-three: true`:
+`AMBASSADOR_WATCHER_LABEL_SELECTOR=mappings.v3alpha1:version-three=true`
+
+You may specify multiple fields delimited by `,` and multiple group selectors delimited by `;`
+
+Example: 
+`AMBASSADOR_WATCHER_LABEL_SELECTOR=secrets.v1:ambassador-secret=true,ambassador-version=v3;mappings.v3alpha1:ambassador-version=v3`
 
 ### `AMBASSADOR_NAMESPACE`
 

--- a/docs/emissary/pre-release/topics/running/environment.md
+++ b/docs/emissary/pre-release/topics/running/environment.md
@@ -167,12 +167,14 @@ Then set `AMBASSADOR_WATCHER_FIELD_SELECTOR=spec.myField` in the  $productName$ 
 Resources without the specified label will be ignored.
 
 You may also specify this on a per-resourcegroup basis. For example to specify a field selector to only fetch secrets of type tls you may use:
-`AMBASSADOR_WATCHER_FIELD_SELECTOR=secrets.v1.:type=kubernetes.io/tls`
+`AMBASSADOR_WATCHER_FIELD_SELECTOR=secrets:type=kubernetes.io/tls`
 
 You may specify multiple fields delimited by `,` and multiple group selectors delimited by `;`
 
 Example: 
-`AMBASSADOR_WATCHER_FIELD_SELECTOR=secrets.v1.:type=kubernetes.io/tls;mappings.v3alpha1:metadata.name=dummy`
+`AMBASSADOR_WATCHER_FIELD_SELECTOR=secrets:type=kubernetes.io/tls;mappings.v3alpha1:metadata.name=dummy`
+
+**Note**: It is possible to enforce the apiversion (example: `myresource.v1alpha1`) for the resourcegroup selector.
 
 ### `AMBASSADOR_WATCHER_LABEL_SELECTOR`
 
@@ -186,7 +188,9 @@ You may also specify this on a per-resourcegroup basis. For example to specify a
 You may specify multiple fields delimited by `,` and multiple group selectors delimited by `;`
 
 Example: 
-`AMBASSADOR_WATCHER_LABEL_SELECTOR=secrets.v1.:ambassador-secret=true,ambassador-version=v3;mappings.v3alpha1:ambassador-version=v3`
+`AMBASSADOR_WATCHER_LABEL_SELECTOR=secrets:ambassador-secret=true,ambassador-version=v3;mappings.v3alpha1:ambassador-version=v3`
+
+**Note**: It is possible to enforce the apiversion (example: `myresource.v1alpha1`) for the resourcegroup selector.
 
 ### `AMBASSADOR_NAMESPACE`
 

--- a/docs/emissary/pre-release/topics/running/scaling.md
+++ b/docs/emissary/pre-release/topics/running/scaling.md
@@ -65,6 +65,10 @@ $productName$'s exact memory usage depends on (among other things) how many `Hos
 `Mapping` resources are defined in your cluster. If this number has grown over time, you may need to
 increase the memory limit defined in your deployment.
 
+**Note**: On big clusters you may want to limit what resources $productName$ can see and work with.
+  This can be achived by defining [AMBASSADOR_WATCHER_FIELD_SELECTOR](../environment/#ambassador_watcher_field_selector) and/or [AMBASSADOR_WATCHER_LABEL_SELECTOR](../environment/#ambassador_watcher_label_selector).
+  Defininig specific selectors can drastically reduce the memory footprint and CPU cycles used to generate the envoy configuration as long as not the entire resource set is required.
+
 ## Liveness probes
 
 $productName$ defines the `/ambassador/v0/check_alive` endpoint on port `8877` for use with Kubernetes


### PR DESCRIPTION
Document the new envs `AMBASSADOR_WATCHER_FIELD_SELECTOR` and `AMBASSADOR_WATCHER_LABEL_SELECTOR`.

Also includes:
* Documents AMBASSADOR_FIELD_SELECTOR (Was nowhere mentioned before, probably because it does not make too much sense but it is in the code)
* Deprecate notes AMBASSADOR_LABEL_SELECTOR and AMBASSADOR_FIELD_SELECTOR
* Add a note how to deal with memory/cpu scaling.

See implementation: https://github.com/emissary-ingress/emissary/pull/4543