### PR TITLE
add target port to service monitor

### DIFF
--- a/docs/emissary/3.3/howtos/prometheus.md
+++ b/docs/emissary/3.3/howtos/prometheus.md
@@ -172,6 +172,9 @@ standard YAML files.  Alternatively, you can install it with
           service: ambassador-admin
       endpoints:
       - port: ambassador-admin
+        path: /metrics
+        scrapeTimeout: 5s
+        targetPort: 8877  
     ```
 
 Prometheus is now configured to gather metrics from $productName$.


### PR DESCRIPTION
Service monitor does work without adding target port