### PR TITLE
Added label selector change note to all 2.5 to 3.x upgrade docs

### DIFF
--- a/docs/edge-stack/3.3/topics/install/upgrade/yaml/edge-stack-2.5/edge-stack-3.3.md
+++ b/docs/edge-stack/3.3/topics/install/upgrade/yaml/edge-stack-2.5/edge-stack-3.3.md
@@ -30,7 +30,17 @@ $productName$ 3.X has been upgraded from Envoy 1.17.X to Envoy 1.22 which remove
 
 You can refer to the [Major changes in $productName$ 3.x](../../../../../../about/changes-3.y/) guide for an overview of the changes.
 
-1. Check Transport Protocol usage on all resources before migrating.
+1. $productName$ 3.2 fixed a bug with `Host.spec.selector\mappingSelector` and `Listener.spec.selector` not being properly enforced.
+   In previous versions, if only a single label from the selector was present on the resource then they would be associated. Additionally, when associating `Hosts` with `Mappings`, if the `Mapping` configured a `hostname` that matched the `hostname` of the `Host` then they would be associated regardless of the configuration of the `selector\mappingSelector` on the `Host`.
+
+   Before upgrading, review your Ambassador resources, and if you make use of the selectors, ensure that every other resource you want it to be associated with contains all the required labels.
+
+   The environment variable `DISABLE_STRICT_LABEL_SELECTORS` can be set to `"true"` on the $productName$ deployment to revert to the
+   old incorrect behavior to help prevent any configuration issues after upgrading in the event that not all manifests making use of the selectors have been corrected yet.
+
+   For more information on `DISABLE_STRICT_LABEL_SELECTORS` see the [Environment Variables page](../../../../../running/environment).
+
+2. Check Transport Protocol usage on all resources before migrating.
 
     The `AuthService`, `RatelimitService`, `LogServices`, and External `Filters` that use the `grpc` protocol will now need to explicilty set `protocol_version: "v3"`. If not set or set to `v2` then an error will be posted and a static response will be returned.
 
@@ -54,7 +64,7 @@ You can refer to the [Major changes in $productName$ 3.x](../../../../../../abou
 	    envoyType "github.com/datawire/ambassador/v2/pkg/api/envoy/type/v3"
     ```
 
-2. Check removed runtime changes
+3. Check removed runtime changes
 
    ```
    # No longer necessary because this was removed from Envoy
@@ -73,7 +83,7 @@ You can refer to the [Major changes in $productName$ 3.x](../../../../../../abou
    "envoy.reloadable_features.enable_deprecated_v2_api": true,
    ```
 
-3. **Install new CRDs.**
+4. **Install new CRDs.**
 
    After reviewing the changes in 3.x and confirming that you are ready to upgrade, the process is the same as upgrading minor versions
    in previous version of $productName$ and does not require the complex migration steps that the migration from 1.x tto 2.x required.
@@ -105,7 +115,7 @@ You can refer to the [Major changes in $productName$ 3.x](../../../../../../abou
     This will create a new certificate with a one year expiration. We will issue a software patch to address this issue well before the one year expiration. Note that certificate renewal will not cause any downtime.
    </Alert>
 
-4. **Install $productName$ $version$.**
+5. **Install $productName$ $version$.**
 
    After installing the new CRDs, upgrade $productName$ $version$:
 

--- a/docs/edge-stack/3.4/topics/install/upgrade/yaml/edge-stack-2.5/edge-stack-3.X.md
+++ b/docs/edge-stack/3.4/topics/install/upgrade/yaml/edge-stack-2.5/edge-stack-3.X.md
@@ -30,7 +30,17 @@ $productName$ 3.X has been upgraded from Envoy 1.17.X to Envoy 1.24.1. Envoy has
 
 You can refer to the [Major changes in $productName$ 3.x](../../../../../../about/changes-3.y/) guide for an overview of the changes. Here are a few items that need to be checked or addressed before upgrading:
 
-1. Check Transport Protocol usage on all resources before migrating.
+1. $productName$ 3.2 fixed a bug with `Host.spec.selector\mappingSelector` and `Listener.spec.selector` not being properly enforced.
+   In previous versions, if only a single label from the selector was present on the resource then they would be associated. Additionally, when associating `Hosts` with `Mappings`, if the `Mapping` configured a `hostname` that matched the `hostname` of the `Host` then they would be associated regardless of the configuration of the `selector\mappingSelector` on the `Host`.
+
+   Before upgrading, review your Ambassador resources, and if you make use of the selectors, ensure that every other resource you want it to be associated with contains all the required labels.
+
+   The environment variable `DISABLE_STRICT_LABEL_SELECTORS` can be set to `"true"` on the $productName$ deployment to revert to the
+   old incorrect behavior to help prevent any configuration issues after upgrading in the event that not all manifests making use of the selectors have been corrected yet.
+
+   For more information on `DISABLE_STRICT_LABEL_SELECTORS` see the [Environment Variables page](../../../../../running/environment).
+
+2. Check Transport Protocol usage on all resources before migrating.
 
     The `AuthService`, `RatelimitService`, `LogServices`, and External `Filters` that use the `grpc` protocol will now need to explicilty set `protocol_version: "v3"`. If not set or set to `v2` then an error will be posted and a static response will be returned.
 
@@ -54,7 +64,7 @@ You can refer to the [Major changes in $productName$ 3.x](../../../../../../abou
 	    envoyType "github.com/datawire/ambassador/v2/pkg/api/envoy/type/v3"
     ```
 
-2. Check removed runtime flags for behavior changes that may affect you:
+3. Check removed runtime flags for behavior changes that may affect you:
 
    ```yaml
    # No longer necessary because this was removed from Envoy
@@ -73,7 +83,7 @@ You can refer to the [Major changes in $productName$ 3.x](../../../../../../abou
    "envoy.reloadable_features.enable_deprecated_v2_api": true,
    ```
 
-3. Support for LightStep tracing driver removed
+4. Support for LightStep tracing driver removed
 
 <Alert severity="warning">
   As of $productName$ 3.4.Z, the <code>LightStep</code> tracing driver is no longer supported. To ensure you do not drop any tracing data, be sure to read before upgrading.

--- a/docs/edge-stack/3.5/topics/install/upgrade/yaml/edge-stack-2.5/edge-stack-3.X.md
+++ b/docs/edge-stack/3.5/topics/install/upgrade/yaml/edge-stack-2.5/edge-stack-3.X.md
@@ -30,7 +30,17 @@ $productName$ 3.X has been upgraded from Envoy 1.17.X to Envoy 1.24.1. Envoy has
 
 You can refer to the [Major changes in $productName$ 3.x](../../../../../../about/changes-3.y/) guide for an overview of the changes. Here are a few items that need to be checked or addressed before upgrading:
 
-1. Check Transport Protocol usage on all resources before migrating.
+1. $productName$ 3.2 fixed a bug with `Host.spec.selector\mappingSelector` and `Listener.spec.selector` not being properly enforced.
+   In previous versions, if only a single label from the selector was present on the resource then they would be associated. Additionally, when associating `Hosts` with `Mappings`, if the `Mapping` configured a `hostname` that matched the `hostname` of the `Host` then they would be associated regardless of the configuration of the `selector\mappingSelector` on the `Host`.
+
+   Before upgrading, review your Ambassador resources, and if you make use of the selectors, ensure that every other resource you want it to be associated with contains all the required labels.
+
+   The environment variable `DISABLE_STRICT_LABEL_SELECTORS` can be set to `"true"` on the $productName$ deployment to revert to the
+   old incorrect behavior to help prevent any configuration issues after upgrading in the event that not all manifests making use of the selectors have been corrected yet.
+
+   For more information on `DISABLE_STRICT_LABEL_SELECTORS` see the [Environment Variables page](../../../../../running/environment).
+
+2. Check Transport Protocol usage on all resources before migrating.
 
     The `AuthService`, `RatelimitService`, `LogServices`, and External `Filters` that use the `grpc` protocol will now need to explicilty set `protocol_version: "v3"`. If not set or set to `v2` then an error will be posted and a static response will be returned.
 
@@ -54,7 +64,7 @@ You can refer to the [Major changes in $productName$ 3.x](../../../../../../abou
 	    envoyType "github.com/datawire/ambassador/v2/pkg/api/envoy/type/v3"
     ```
 
-2. Check removed runtime flags for behavior changes that may affect you:
+3. Check removed runtime flags for behavior changes that may affect you:
 
    ```yaml
    # No longer necessary because this was removed from Envoy
@@ -73,7 +83,7 @@ You can refer to the [Major changes in $productName$ 3.x](../../../../../../abou
    "envoy.reloadable_features.enable_deprecated_v2_api": true,
    ```
 
-3. Support for LightStep tracing driver removed
+4. Support for LightStep tracing driver removed
 
 <Alert severity="warning">
   As of $productName$ 3.4.Z, the <code>LightStep</code> tracing driver is no longer supported. To ensure you do not drop any tracing data, be sure to read before upgrading.

--- a/docs/edge-stack/3.6/topics/install/upgrade/yaml/edge-stack-2.5/edge-stack-3.X.md
+++ b/docs/edge-stack/3.6/topics/install/upgrade/yaml/edge-stack-2.5/edge-stack-3.X.md
@@ -30,7 +30,17 @@ $productName$ 3.X has been upgraded from Envoy 1.17.X to Envoy 1.24.1. Envoy has
 
 You can refer to the [Major changes in $productName$ 3.x](../../../../../../about/changes-3.y/) guide for an overview of the changes. Here are a few items that need to be checked or addressed before upgrading:
 
-1. Check Transport Protocol usage on all resources before migrating.
+1. $productName$ 3.2 fixed a bug with `Host.spec.selector\mappingSelector` and `Listener.spec.selector` not being properly enforced.
+   In previous versions, if only a single label from the selector was present on the resource then they would be associated. Additionally, when associating `Hosts` with `Mappings`, if the `Mapping` configured a `hostname` that matched the `hostname` of the `Host` then they would be associated regardless of the configuration of the `selector\mappingSelector` on the `Host`.
+
+   Before upgrading, review your Ambassador resources, and if you make use of the selectors, ensure that every other resource you want it to be associated with contains all the required labels.
+
+   The environment variable `DISABLE_STRICT_LABEL_SELECTORS` can be set to `"true"` on the $productName$ deployment to revert to the
+   old incorrect behavior to help prevent any configuration issues after upgrading in the event that not all manifests making use of the selectors have been corrected yet.
+
+   For more information on `DISABLE_STRICT_LABEL_SELECTORS` see the [Environment Variables page](../../../../../running/environment).
+
+2. Check Transport Protocol usage on all resources before migrating.
 
     The `AuthService`, `RatelimitService`, `LogServices`, and External `Filters` that use the `grpc` protocol will now need to explicilty set `protocol_version: "v3"`. If not set or set to `v2` then an error will be posted and a static response will be returned.
 
@@ -54,7 +64,7 @@ You can refer to the [Major changes in $productName$ 3.x](../../../../../../abou
 	    envoyType "github.com/datawire/ambassador/v2/pkg/api/envoy/type/v3"
     ```
 
-2. Check removed runtime flags for behavior changes that may affect you:
+3. Check removed runtime flags for behavior changes that may affect you:
 
    ```yaml
    # No longer necessary because this was removed from Envoy
@@ -73,7 +83,7 @@ You can refer to the [Major changes in $productName$ 3.x](../../../../../../abou
    "envoy.reloadable_features.enable_deprecated_v2_api": true,
    ```
 
-3. Support for LightStep tracing driver removed
+4. Support for LightStep tracing driver removed
 
 <Alert severity="warning">
   As of $productName$ 3.4.Z, the <code>LightStep</code> tracing driver is no longer supported. To ensure you do not drop any tracing data, be sure to read before upgrading.

--- a/docs/edge-stack/3.7/topics/install/upgrade/yaml/edge-stack-2.5/edge-stack-3.X.md
+++ b/docs/edge-stack/3.7/topics/install/upgrade/yaml/edge-stack-2.5/edge-stack-3.X.md
@@ -30,7 +30,17 @@ $productName$ 3.X has been upgraded from Envoy 1.17.X to Envoy 1.24.1. Envoy has
 
 You can refer to the [Major changes in $productName$ 3.x](../../../../../../about/changes-3.y/) guide for an overview of the changes. Here are a few items that need to be checked or addressed before upgrading:
 
-1. Check Transport Protocol usage on all resources before migrating.
+1. $productName$ 3.2 fixed a bug with `Host.spec.selector\mappingSelector` and `Listener.spec.selector` not being properly enforced.
+   In previous versions, if only a single label from the selector was present on the resource then they would be associated. Additionally, when associating `Hosts` with `Mappings`, if the `Mapping` configured a `hostname` that matched the `hostname` of the `Host` then they would be associated regardless of the configuration of the `selector\mappingSelector` on the `Host`.
+
+   Before upgrading, review your Ambassador resources, and if you make use of the selectors, ensure that every other resource you want it to be associated with contains all the required labels.
+
+   The environment variable `DISABLE_STRICT_LABEL_SELECTORS` can be set to `"true"` on the $productName$ deployment to revert to the
+   old incorrect behavior to help prevent any configuration issues after upgrading in the event that not all manifests making use of the selectors have been corrected yet.
+
+   For more information on `DISABLE_STRICT_LABEL_SELECTORS` see the [Environment Variables page](../../../../../running/environment).
+
+2. Check Transport Protocol usage on all resources before migrating.
 
     The `AuthService`, `RatelimitService`, `LogServices`, and External `Filters` that use the `grpc` protocol will now need to explicilty set `protocol_version: "v3"`. If not set or set to `v2` then an error will be posted and a static response will be returned.
 
@@ -54,7 +64,7 @@ You can refer to the [Major changes in $productName$ 3.x](../../../../../../abou
 	    envoyType "github.com/datawire/ambassador/v2/pkg/api/envoy/type/v3"
     ```
 
-2. Check removed runtime flags for behavior changes that may affect you:
+3. Check removed runtime flags for behavior changes that may affect you:
 
    ```yaml
    # No longer necessary because this was removed from Envoy
@@ -73,7 +83,7 @@ You can refer to the [Major changes in $productName$ 3.x](../../../../../../abou
    "envoy.reloadable_features.enable_deprecated_v2_api": true,
    ```
 
-3. Support for LightStep tracing driver removed
+4. Support for LightStep tracing driver removed
 
 <Alert severity="warning">
   As of $productName$ 3.4.Z, the <code>LightStep</code> tracing driver is no longer supported. To ensure you do not drop any tracing data, be sure to read before upgrading.

--- a/docs/edge-stack/latest/topics/install/upgrade/yaml/edge-stack-2.5/edge-stack-3.X.md
+++ b/docs/edge-stack/latest/topics/install/upgrade/yaml/edge-stack-2.5/edge-stack-3.X.md
@@ -30,7 +30,17 @@ $productName$ 3.X has been upgraded from Envoy 1.17.X to Envoy 1.24.1. Envoy has
 
 You can refer to the [Major changes in $productName$ 3.x](../../../../../../about/changes-3.y/) guide for an overview of the changes. Here are a few items that need to be checked or addressed before upgrading:
 
-1. Check Transport Protocol usage on all resources before migrating.
+1. $productName$ 3.2 fixed a bug with `Host.spec.selector\mappingSelector` and `Listener.spec.selector` not being properly enforced.
+   In previous versions, if only a single label from the selector was present on the resource then they would be associated. Additionally, when associating `Hosts` with `Mappings`, if the `Mapping` configured a `hostname` that matched the `hostname` of the `Host` then they would be associated regardless of the configuration of the `selector\mappingSelector` on the `Host`.
+
+   Before upgrading, review your Ambassador resources, and if you make use of the selectors, ensure that every other resource you want it to be associated with contains all the required labels.
+
+   The environment variable `DISABLE_STRICT_LABEL_SELECTORS` can be set to `"true"` on the $productName$ deployment to revert to the
+   old incorrect behavior to help prevent any configuration issues after upgrading in the event that not all manifests making use of the selectors have been corrected yet.
+
+   For more information on `DISABLE_STRICT_LABEL_SELECTORS` see the [Environment Variables page](../../../../../running/environment).
+
+2. Check Transport Protocol usage on all resources before migrating.
 
     The `AuthService`, `RatelimitService`, `LogServices`, and External `Filters` that use the `grpc` protocol will now need to explicilty set `protocol_version: "v3"`. If not set or set to `v2` then an error will be posted and a static response will be returned.
 
@@ -54,7 +64,7 @@ You can refer to the [Major changes in $productName$ 3.x](../../../../../../abou
 	    envoyType "github.com/datawire/ambassador/v2/pkg/api/envoy/type/v3"
     ```
 
-2. Check removed runtime flags for behavior changes that may affect you:
+3. Check removed runtime flags for behavior changes that may affect you:
 
    ```yaml
    # No longer necessary because this was removed from Envoy
@@ -73,7 +83,7 @@ You can refer to the [Major changes in $productName$ 3.x](../../../../../../abou
    "envoy.reloadable_features.enable_deprecated_v2_api": true,
    ```
 
-3. Support for LightStep tracing driver removed
+4. Support for LightStep tracing driver removed
 
 <Alert severity="warning">
   As of $productName$ 3.4.Z, the <code>LightStep</code> tracing driver is no longer supported. To ensure you do not drop any tracing data, be sure to read before upgrading.

--- a/docs/edge-stack/pre-release/topics/install/upgrade/yaml/edge-stack-2.5/edge-stack-3.X.md
+++ b/docs/edge-stack/pre-release/topics/install/upgrade/yaml/edge-stack-2.5/edge-stack-3.X.md
@@ -30,7 +30,17 @@ $productName$ 3.X has been upgraded from Envoy 1.17.X to Envoy 1.24.1. Envoy has
 
 You can refer to the [Major changes in $productName$ 3.x](../../../../../../about/changes-3.y/) guide for an overview of the changes. Here are a few items that need to be checked or addressed before upgrading:
 
-1. Check Transport Protocol usage on all resources before migrating.
+1. $productName$ 3.2 fixed a bug with `Host.spec.selector\mappingSelector` and `Listener.spec.selector` not being properly enforced.
+   In previous versions, if only a single label from the selector was present on the resource then they would be associated. Additionally, when associating `Hosts` with `Mappings`, if the `Mapping` configured a `hostname` that matched the `hostname` of the `Host` then they would be associated regardless of the configuration of the `selector\mappingSelector` on the `Host`.
+
+   Before upgrading, review your Ambassador resources, and if you make use of the selectors, ensure that every other resource you want it to be associated with contains all the required labels.
+
+   The environment variable `DISABLE_STRICT_LABEL_SELECTORS` can be set to `"true"` on the $productName$ deployment to revert to the
+   old incorrect behavior to help prevent any configuration issues after upgrading in the event that not all manifests making use of the selectors have been corrected yet.
+
+   For more information on `DISABLE_STRICT_LABEL_SELECTORS` see the [Environment Variables page](../../../../../running/environment).
+
+2. Check Transport Protocol usage on all resources before migrating.
 
     The `AuthService`, `RatelimitService`, `LogServices`, and External `Filters` that use the `grpc` protocol will now need to explicilty set `protocol_version: "v3"`. If not set or set to `v2` then an error will be posted and a static response will be returned.
 
@@ -54,7 +64,7 @@ You can refer to the [Major changes in $productName$ 3.x](../../../../../../abou
 	    envoyType "github.com/datawire/ambassador/v2/pkg/api/envoy/type/v3"
     ```
 
-2. Check removed runtime flags for behavior changes that may affect you:
+3. Check removed runtime flags for behavior changes that may affect you:
 
    ```yaml
    # No longer necessary because this was removed from Envoy
@@ -73,7 +83,7 @@ You can refer to the [Major changes in $productName$ 3.x](../../../../../../abou
    "envoy.reloadable_features.enable_deprecated_v2_api": true,
    ```
 
-3. Support for LightStep tracing driver removed
+4. Support for LightStep tracing driver removed
 
 <Alert severity="warning">
   As of $productName$ 3.4.Z, the <code>LightStep</code> tracing driver is no longer supported. To ensure you do not drop any tracing data, be sure to read before upgrading.


### PR DESCRIPTION
Added the note from the 2.5 to 3.2 upgrade guide about the label selector change to all 3.2+ docs. Customers were running into issues because they would follow our 3.3+ upgrade docs and not know about this change.