### PR TITLE
Fix typo in indentation

### DIFF
--- a/docs/emissary/3.4/howtos/rate-limiting-tutorial.md
+++ b/docs/emissary/3.4/howtos/rate-limiting-tutorial.md
@@ -122,7 +122,7 @@ spec:
     emissary:
       - request_label_group:
         - x-emissary-test-allow:
-          request_headers:
+            request_headers:
               key: "x-emissary-test-allow"
               header_name: "x-emissary-test-allow"
 ```


### PR DESCRIPTION
Fix the typo in indentation in the documentation